### PR TITLE
Fix echo typo in shell login template

### DIFF
--- a/.chezmoitemplates/shell-login-common.tmpl
+++ b/.chezmoitemplates/shell-login-common.tmpl
@@ -17,6 +17,6 @@ if [ -n "$SSH_CLIENT" ]; then
 	echo "Connecting from $SSH_CLIENT"
 fi
 if [ -n "$DISPLAY" ]; then 
-	echo "Dispaly is set ${DISPLAY}"
+	echo "Display is set ${DISPLAY}"
 fi
 echo "Chezmoi last generated {{ now }}"


### PR DESCRIPTION
## Summary
- correct spelling of "Display" in shell login template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fea2cc61c832fb7eeb93faf8066d5