### PR TITLE
Improve git credential oauth detection

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -61,6 +61,15 @@
 #{{ end }} End OS Specific code
 
 {{- $gitCredentialManagerLocation := findExecutable "bin/git-credential-manager" $binroots -}}
+{{- $gitCredentialOAuthLocation := "" -}}
+{{- if stat (joinPath .chezmoi.homeDir "/.local/bin/git-credential-oauth") -}}
+  {{- $gitCredentialOAuthLocation = joinPath .chezmoi.homeDir "/.local/bin/git-credential-oauth" -}}
+{{- else -}}
+  {{- $gitCredentialOAuthLocation = findExecutable "bin/git-credential-oauth" $binroots -}}
+  {{- if eq $gitCredentialOAuthLocation "" -}}
+    {{- $gitCredentialOAuthLocation = lookPath "git-credential-oauth" -}}
+  {{- end -}}
+{{- end -}}
 {{- $vimdiffLocation := findExecutable "bin/vimdiff" $binroots -}}
 {{- $nvimdiffLocation := findExecutable "bin/nvimdiff" $binroots -}}
 {{- $kdiff3Location := findExecutable "bin/kdiff3" $binroots -}}
@@ -133,6 +142,7 @@
         isDevcontainer={{ $isDevcontainer }}
         isGnome={{ $isGnome }}
         gitCredentialManagerLocation="{{ $gitCredentialManagerLocation }}"
+        gitCredentialOAuthLocation="{{ $gitCredentialOAuthLocation }}"
         vimdiffLocation="{{ $vimdiffLocation }}"
         nvimdiffLocation="{{ $nvimdiffLocation }}"
         kdiff3Location="{{ $kdiff3Location }}"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -28,10 +28,19 @@
 	useHttpPath = true
 
 [credential]
+{{ $oauthHelper := (index . "gitCredentialOAuthLocation") }}
+{{ if ne $oauthHelper "" }}
+  helper = cache --timeout 21600 # six hours
+  {{ if index . "headless" }}
+  helper = oauth -device
+  {{ else }}
+  helper = oauth
+  {{ end }}
+{{ end }}
 {{ if index . "headless" }}
-	credentialStore = cache
-	cacheOptions = "--timeout 14400"
-	helper = {{ index $ "gitCredentialManagerLocation" }}
+        credentialStore = cache
+        cacheOptions = "--timeout 14400"
+        helper = {{ index $ "gitCredentialManagerLocation" }}
 {{ else if eq .chezmoi.os "linux" }}
 	{{ if eq .chezmoi.osRelease.id "ubuntu" }}
 	       credentialStore = secretservice


### PR DESCRIPTION
## Summary
- check `$HOME/.local/bin/git-credential-oauth` before other search locations
- use the oauth helper name when found and switch to `-device` on headless systems

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6845755e808c832fbd5910fb79763170