### PR TITLE
Add git user name fallback logic

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -7,6 +7,8 @@
 {{- $headless := promptBool "headless" $headlessGuess -}}
 {{- $gpgconfigured := promptBool "gpgconfigured" $gpgconfiguredGuess -}}
 {{- $autoGit := promptBool "auto git?" true -}}
+{{- $gitUserName := promptString "git user.name" (trimSpace (output "sh" "-c" "git config --get user.name 2>/dev/null || getent passwd $(id -un) | cut -d ':' -f5 | cut -d ',' -f1 || getent passwd $(id -un) | cut -d ':' -f1")) -}}
+{{- $gitUserEmail := promptString "git user.email" (trimSpace (output "sh" "-c" "git config --get user.email 2>/dev/null || true")) -}}
 
 {{- $optbins := (list) -}}
 {{- $usrbins := (list) -}}
@@ -141,6 +143,8 @@
         isWsl={{ $isWsl }}
         isDevcontainer={{ $isDevcontainer }}
         isGnome={{ $isGnome }}
+        gitUserName="{{ $gitUserName }}"
+        gitUserEmail="{{ $gitUserEmail }}"
         gitCredentialManagerLocation="{{ $gitCredentialManagerLocation }}"
         gitCredentialOAuthLocation="{{ $gitCredentialOAuthLocation }}"
         vimdiffLocation="{{ $vimdiffLocation }}"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,6 +1,7 @@
 [user]
-	name = Arran Ubels
-	useConfigOnly = true
+  name = {{ index . "gitUserName" }}
+  email = {{ index . "gitUserEmail" }}
+  useConfigOnly = true
 [init]
 	defaultBranch=main
 [core]


### PR DESCRIPTION
## Summary
- improve git user name prompt fallback in `.chezmoi.toml.tmpl`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_684e620b7338832f876d0abe6c463dcc