### PR TITLE
Add GitHub release helper

### DIFF
--- a/dot_local/bin/executable_gh-release.sh
+++ b/dot_local/bin/executable_gh-release.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+version=$(git-tag-inc "$@" -print-version-only)
+git-tag-inc "$@"
+gh release create "$version" --generate-notes
+


### PR DESCRIPTION
## Summary
- add a helper script to create GitHub releases
- support git-tag-inc flags when generating tags

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: template function `trimSpace` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ed003dd68832fb0df28094c17525b