### PR TITLE
Fix template build with older chezmoi

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -7,8 +7,8 @@
 {{- $headless := promptBool "headless" $headlessGuess -}}
 {{- $gpgconfigured := promptBool "gpgconfigured" $gpgconfiguredGuess -}}
 {{- $autoGit := promptBool "auto git?" true -}}
-{{- $gitUserName := promptString "git user.name" (trimSpace (output "sh" "-c" "git config --get user.name 2>/dev/null || getent passwd $(id -un) | cut -d ':' -f5 | cut -d ',' -f1 || getent passwd $(id -un) | cut -d ':' -f1")) -}}
-{{- $gitUserEmail := promptString "git user.email" (trimSpace (output "sh" "-c" "git config --get user.email 2>/dev/null || true")) -}}
+{{- $gitUserName := promptString "git user.name" (trim (output "sh" "-c" "git config --get user.name 2>/dev/null || getent passwd $(id -un) | cut -d ':' -f5 | cut -d ',' -f1 || getent passwd $(id -un) | cut -d ':' -f1")) -}}
+{{- $gitUserEmail := promptString "git user.email" (trim (output "sh" "-c" "git config --get user.email 2>/dev/null || true")) -}}
 
 {{- $optbins := (list) -}}
 {{- $usrbins := (list) -}}


### PR DESCRIPTION
## Summary
- replace deprecated `trimSpace` with `trim`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: `function "trimSpace" not defined`)*
- `yes "" | bin/chezmoi init --source $PWD --destination /tmp/chezmoi_test --no-tty --apply`

------
https://chatgpt.com/codex/tasks/task_e_684ed27e973c832fa0cd3e666981d60f