### PR TITLE
Update missing tool check

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -128,6 +128,10 @@
         {{- writeToStdout "Can't find GCM: https://github.com/GitCredentialManager/git-credential-manager/releases \n" -}}
 {{- end -}}
 
+{{- if not (stat $gitCredentialOAuthLocation ) -}}
+        {{- writeToStdout "Can't find git-credential-oauth \n" -}}
+{{- end -}}
+
 {{- if and (eq .chezmoi.os "linux") (not (stat $neovimLocation)) -}}
         {{- writeToStdout "Can't find neovim \n" -}}
 {{- end -}}
@@ -221,6 +225,8 @@
         zshLocation="{{$zshLocation}}"
         lessLocation="{{$lessLocation}}"
         mvnLocation="{{$mvnLocation}}"
+        zellijLocation="{{$zellijLocation}}"
+        tmuxLocation="{{$tmuxLocation}}"
         ghLocation="{{$ghLocation}}"
         gitTagIncLocation="{{$gitTagIncLocation}}"
         rarLocation="{{$rarLocation}}"


### PR DESCRIPTION
## Summary
- report missing `git-credential-oauth` when applying configs
- output `zellij` and `tmux` paths in collected data

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_684ff0568714832f80338ff5b3e90e57