### PR TITLE
Use findOneExecutable for git pager

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -10,16 +10,9 @@
 	excludesfile = {{ .chezmoi.homeDir }}/.config/git/ignore
 	longpaths = true
 	# quotepath = false # Unicode characters
-{{ if lookPath "delta" }}
-    pager = delta
-{{ else if lookPath "nvimpager" }}
-    pager = nvimpager
-{{ else if lookPath "vimpager" }}
-    pager = vimpager
-{{ else if lookPath "nvim" }}
-    pager = nvim
-{{ else if lookPath "vim" }}
-    pager = vim
+{{- $pager := findOneExecutable (list "delta" "nvimpager" "vimpager" "nvim" "vim") -}}
+{{ if ne $pager "" }}
+    pager = {{ $pager }}
 {{ end }}
 
 [rerere]


### PR DESCRIPTION
## Summary
- simplify pager selection in `dot_gitconfig.tmpl` by using `findOneExecutable`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_684ffd2a9e64832faa9777cf0161ae38