### PR TITLE
Update zsh detection logic in bash login

### DIFF
--- a/dot_bash_login.tmpl
+++ b/dot_bash_login.tmpl
@@ -4,10 +4,11 @@
 
 # From https://github.com/jordansissel/dotfiles/blob/master/.bash_profile
 # Exec zsh if it exists.
-if test -x `which zsh`; then
-	echo "zsh found on system "
-else
-	echo "No zsh found, sorry I couldn't save you..."
-fi
+{{- $zshLocation := index . "zshLocation" -}}
+{{- if stat $zshLocation -}}
+echo "zsh found on system"
+{{- else -}}
+echo "No zsh found, sorry I couldn't save you..."
+{{- end -}}
 
 # SSH Agent if required


### PR DESCRIPTION
## Summary
- use `zshLocation` from chezmoi data instead of searching PATH at runtime

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: findOneExecutable wrong number of args)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd28175c832f960fccdc36c7edae