### PR TITLE
Integrate git pager configuration

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -79,6 +79,7 @@
 {{- $neovimLocation := findExecutable "bin/nvim" $binroots -}}
 {{- $vimpagerLocation := findExecutable "bin/vimpager" $binroots -}}
 {{- $nvimpagerLocation := findExecutable "bin/nvimpager" $binroots -}}
+{{- $gitPagerLocation := findOneExecutable (list "delta" "nvimpager" "vimpager" "nvim" "vim") $binroots -}}
 {{- $zshLocation := findExecutable "bin/zsh" $binroots -}}
 {{- $lessLocation := findExecutable "bin/less" $binroots -}}
 {{- $mvnLocation := findExecutable "bin/mvn" $binroots -}}
@@ -146,6 +147,9 @@
 
 {{- if and (eq .chezmoi.os "linux") (not (stat $vimpagerLocation)) -}}
         {{- writeToStdout "Can't find vimpager \n" -}}
+{{- end -}}
+{{- if not (stat $gitPagerLocation ) -}}
+        {{- writeToStdout "Can't find suitable git pager \n" -}}
 {{- end -}}
 
 {{- if and (not (eq .chezmoi.os "windows")) (not (stat $zellijLocation)) -}}
@@ -221,6 +225,7 @@
         neovimLocation="{{ $neovimLocation }}"
         vimpagerLocation="{{ $vimpagerLocation }}"
         nvimpagerLocation="{{ $nvimpagerLocation }}"
+        gitPagerLocation="{{ $gitPagerLocation }}"
         gpgLocation="{{$gpgLocation}}"
         zshLocation="{{$zshLocation}}"
         lessLocation="{{$lessLocation}}"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -10,10 +10,10 @@
 	excludesfile = {{ .chezmoi.homeDir }}/.config/git/ignore
 	longpaths = true
 	# quotepath = false # Unicode characters
-{{- $pager := findOneExecutable (list "delta" "nvimpager" "vimpager" "nvim" "vim") -}}
-{{ if ne $pager "" }}
+{{- $pager := index . "gitPagerLocation" -}}
+{{- if ne $pager "" }}
     pager = {{ $pager }}
-{{ end }}
+{{- end }}
 
 [rerere]
   enabled = 1


### PR DESCRIPTION
## Summary
- define `gitPagerLocation` in `.chezmoi.toml.tmpl`
- export pager path in [data] section
- use the new variable inside `dot_gitconfig.tmpl`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: template `promptContext` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68500101b518832f9da2da981580982d