### PR TITLE
Use findOneExecutable for Chrome

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -124,6 +124,15 @@
   {{- $xinputLocation = lookPath "xinput" -}}
 {{- end -}}
 
+{{- $chromeLocation := findOneExecutable (list
+  "bin/google-chrome"
+  "bin/google-chrome-stable"
+  "bin/google-chrome-unstable"
+  "bin/google-chrome-beta") $binroots -}}
+{{- if eq $chromeLocation "" -}}
+        {{- writeToStdout "Can't find chrome \n" -}}
+{{- end -}}
+
 {{- if and (eq .chezmoi.os "linux") (not (stat $gitCredentialManagerLocation )) -}}
         {{- writeToStdout "Can't find GCM: https://github.com/GitCredentialManager/git-credential-manager/releases \n" -}}
 {{- end -}}
@@ -233,6 +242,7 @@
         sevenZipLocation="{{$sevenZipLocation}}"
         digLocation="{{$digLocation}}"
         xinputLocation="{{$xinputLocation}}"
+        chromeLocation="{{$chromeLocation}}"
         optbins = [{{range $each := $optbins}}"{{$each}}", {{end}}]
         usrbins = [{{range $each := $usrbins}}"{{$each}}", {{end}}]
         usrlocalbins = [{{range $each := $usrlocalbins}}"{{$each}}", {{end}}]

--- a/.chezmoitemplates/dev-utils-env.tmpl
+++ b/.chezmoitemplates/dev-utils-env.tmpl
@@ -10,6 +10,7 @@
 # colored GCC warnings and errors
 #export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
 
-if command -v google-chrome-stable >/dev/null 2>&1; then
-  export CHROME_EXECUTABLE="$(command -v google-chrome-stable)"
-fi
+{{- $chromeExe := index . "chromeLocation" -}}
+{{- if and (ne $chromeExe "") (stat $chromeExe) -}}
+export CHROME_EXECUTABLE="{{$chromeExe}}"
+{{- end -}}


### PR DESCRIPTION
## Summary
- simplify Chrome detection using only `findOneExecutable`
- warn when no Chrome executable is found

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: template "promptContext" not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd25b430832fa9c55368019b904e