### PR TITLE
Fix shell prompt variable scope

### DIFF
--- a/.chezmoitemplates/prompt.tmpl
+++ b/.chezmoitemplates/prompt.tmpl
@@ -1,49 +1,36 @@
 {{- $shell := index . "shell" -}}
 
-{{- define "promptContext" -}}
+{{- if or (eq $shell "zsh") (eq $shell "bash") (eq $shell "ksh") (eq $shell "tcsh") -}}
 ctx=""
 if test -n "${TMUX}"; then
-  ctx="${ctx}:tmux"
+  ctx="tmux"
   if test "$SHLVL" -gt 2; then
     ctx="${ctx}:${SHLVL}"
   fi
 else
   if test "$SHLVL" -gt 1; then
-    ctx="${ctx}:${SHLVL}"
+    ctx="${SHLVL}"
   fi
 fi
 if test -n "${ctx}"; then
   ctx="(${ctx})"
 fi
-{{- end -}}
 
-{{- define "promptChar" -}}
 pchar="$"
 if test "$(id -u)" -eq 0; then
   pchar="#"
 fi
-{{- end -}}
 
-{{- if eq $shell "zsh" -}}
+  {{- if eq $shell "zsh" -}}
 export SPROMPT="Potential spelling error %R , could be %r"
-{{ template "promptContext" $ }}
-{{ template "promptChar" $ }}
 export PROMPT='%n@%m:%~ ${ctx}\n'"${pchar} "
-unset ctx pchar
-{{- else if eq $shell "bash" -}}
-{{ template "promptContext" $ }}
-{{ template "promptChar" $ }}
+  {{- else if eq $shell "bash" -}}
 export PS1='\u@\h:\w ${ctx}\n'"${pchar} "
-unset ctx pchar
-{{- else if eq $shell "ksh" -}}
-{{ template "promptContext" $ }}
-{{ template "promptChar" $ }}
+  {{- else if eq $shell "ksh" -}}
 export PS1='${USER}@$(hostname -s):${PWD} ${ctx}\n'"${pchar} "
-unset ctx pchar
-{{- else if eq $shell "tcsh" -}}
-{{ template "promptContext" $ }}
-{{ template "promptChar" $ }}
+  {{- else if eq $shell "tcsh" -}}
 set prompt="%n@%m:%~ ${ctx}\n${pchar} "
+  {{- end -}}
 unset ctx pchar
 {{- else -}}
 # Unknown shell for prompt


### PR DESCRIPTION
## Summary
- compute prompt variables only when shell is recognised

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: template "promptContext" not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68500c33ae18832fb16f9bc1b688dfea