### PR TITLE
Add shell config lint step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,15 @@ jobs:
           shellcheck **/*.sh
       - run: |
           yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --source=$PWD --apply
+      - name: Verify shell configuration parses
+        run: |
+          for f in ~/.bashrc ~/.bash_profile ~/.bash_login ~/.bash_logout ~/.profile; do
+            if [ -f "$f" ]; then
+              bash -n "$f"
+            fi
+          done
+          for f in ~/.zshrc ~/.zprofile ~/.zlogin ~/.zlogout ~/.zshenv; do
+            if [ -f "$f" ]; then
+              zsh -n "$f"
+            fi
+          done


### PR DESCRIPTION
## Summary
- check .bashrc, .bash_profile and zsh files with their shells in CI

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --source=$PWD --apply`
- `for f in ~/.bashrc ~/.bash_profile ~/.bash_login ~/.bash_logout ~/.profile; do if [ -f "$f" ]; then bash -n "$f"; fi; done`

------
https://chatgpt.com/codex/tasks/task_e_6850e74f9a44832f8dccccb3f781a8c1