### PR TITLE
Fix tests by installing zsh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install ShellCheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Install ShellCheck and zsh
+        run: sudo apt-get update && sudo apt-get install -y shellcheck zsh
       - run: |
           shopt -s globstar
           shellcheck **/*.sh


### PR DESCRIPTION
## Summary
- ensure zsh is installed during CI

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6850f1ede0f8832f858922a9a3f22a01