### PR TITLE
docs: clarify oauth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,35 @@ of PR or issues.
 # Interesting tools:
 
 * https://github.com/tep/terminal-decor
+
+## Encrypting credentials with ejson
+
+Use ejson to store secrets such as a GitLab OAuth client ID. Create an encrypted
+file named `private_gitlab_oauth.ejson`:
+
+1. Install [ejson](https://github.com/Shopify/ejson).
+2. Generate a keypair and save the secret key:
+
+   ```sh
+   ejson keygen -w
+   ```
+
+   Note the printed public key and keep the private key in the output path.
+3. Create `private_gitlab_oauth.ejson` containing your public key and OAuth client ID:
+
+   ```json
+   {
+     "_public_key": "<public key>",
+     "gitlab_oauth_client_id": "<your client ID>"
+   }
+   ```
+
+4. Encrypt the file:
+
+   ```sh
+   ejson encrypt private_gitlab_oauth.ejson
+   ```
+
+Store the private key where `ejson` can read it when applying your dotfiles.
+Feel free to change the JSON keys to suit whichever credentials you need to
+encrypt.

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -61,11 +61,8 @@
     provider = generic
 
 [credential "https://gitlab.arran.net.au"]
-  # provider = generic
-  # provider = gitlab
-	gitLabAuthModes = pat
-	# gitLabDevClientId = FUCK
-	# gitLabDevClientSecret FUCK
+  gitLabAuthModes = pat
+  # oauthClientId = {{/* (ejsonDecrypt "private_gitlab_oauth.ejson").gitlab_oauth_client_id */}}
 
 {{ if ne .chezmoi.os "windows" }}
 [color]


### PR DESCRIPTION
## Summary
- document how to encrypt credentials with ejson more generally
- comment out the template function in `.gitconfig`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68511f188a98832fb326196e85a5fde6