### PR TITLE
Add keychain defaults to SSH config

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,25 @@ file named `private_gitlab_oauth.ejson`:
 Store the private key where `ejson` can read it when applying your dotfiles.
 Feel free to change the JSON keys to suit whichever credentials you need to
 encrypt.
+
+## SSH configuration
+
+The default SSH configuration adds keys to your agent, stores passphrases in the
+macOS keychain and limits authentication to the specified identities:
+
+```sshconfig
+Host *
+  UseKeychain yes
+  AddKeysToAgent yes
+  IdentitiesOnly yes
+```
+
+To disable or override these options, create another `Host` block with your
+preferred values. For example:
+
+```sshconfig
+Host legacy.example.com
+  UseKeychain no
+  AddKeysToAgent no
+  IdentitiesOnly no
+```

--- a/private_dot_ssh/private_config
+++ b/private_dot_ssh/private_config
@@ -5,4 +5,17 @@ Compression yes
 ControlMaster auto
 ControlPath ~/.ssh/cm_socket/%r@%h:%p
 
+# Default key handling
+Host *
+  UseKeychain yes
+  AddKeysToAgent yes
+  IdentitiesOnly yes
+
+# To override these options for a specific host, create another Host block
+# with the desired settings, e.g.:
+# Host example.com
+#   UseKeychain no
+#   AddKeysToAgent no
+#   IdentitiesOnly no
+
 # vim: set ft=sshconfig:


### PR DESCRIPTION
## Summary
- extend SSH config template with key management directives
- document SSH defaults and how to disable them in README

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_685220bdff30832fad2238497380df3a