### PR TITLE
Add system script support to xinitrc

### DIFF
--- a/dot_xinitrc
+++ b/dot_xinitrc
@@ -1,0 +1,10 @@
+# ~/.xinitrc
+# Source scripts in /etc/X11/xinit/xinitrc.d when present.
+# This allows system packages to configure the X session.
+if [ -d /etc/X11/xinit/xinitrc.d ]; then
+  for f in /etc/X11/xinit/xinitrc.d/*; do
+    [ -x "$f" ] && . "$f"
+  done
+  unset f
+fi
+


### PR DESCRIPTION
## Summary
- create `.xinitrc` to source scripts under `/etc/X11/xinit/xinitrc.d`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_685220523318832f8e7664d5630b58bf