### PR TITLE
Update shell RC templates for GPG pinentry

### DIFF
--- a/.chezmoitemplates/gpg-tty.tmpl
+++ b/.chezmoitemplates/gpg-tty.tmpl
@@ -1,0 +1,11 @@
+{{- $shell := index . "shell" -}}
+{{- if eq $shell "tcsh" }}
+if ( $?prompt ) then
+  setenv GPG_TTY `tty`
+endif
+{{- else }}
+if [[ $- == *i* ]]; then
+  GPG_TTY=$(tty)
+  export GPG_TTY
+fi
+{{- end }}

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -7,3 +7,5 @@ case $- in
 esac
 
 {{ template "prompt.tmpl" deepCopy $ | merge (dict "shell" "bash") }}
+
+{{ template "gpg-tty.tmpl" deepCopy $ | merge (dict "shell" "bash") }}

--- a/dot_tcshrc.tmpl
+++ b/dot_tcshrc.tmpl
@@ -4,3 +4,5 @@
 
 {{ template "shell-aliases.tmpl" $ }}
 
+{{ template "gpg-tty.tmpl" deepCopy $ | merge (dict "shell" "tcsh") }}
+

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -91,5 +91,7 @@ autoload -U colors && colors
 
 {{ template "atuin.tmpl" deepCopy $ | merge (dict "shell" "zsh") }}
 
+{{ template "gpg-tty.tmpl" deepCopy $ | merge (dict "shell" "zsh") }}
+
 return # This prevents scripts which append their own installers from "working"
 {{/* vim: set filetype=zsh: */}}


### PR DESCRIPTION
## Summary
- add shared template to export `GPG_TTY` when running interactively
- use the new template in bashrc, zshrc and tcshrc

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_685220860384832f8d150079173d0850