### PR TITLE
Refactor README: replace Tools section with benefits overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,73 +21,31 @@ and scripts I have put in intentionally, these could go unnoticed or taken for g
 other systems harder.) Saying that please pick out what you like / want. I am also happy to take suggestions in the form
 of PR or issues.
 
-# Tools:
 
-| Tool                                                        | Symbols                    | What                                                                                                                                 |
-|-------------------------------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| [Chezmoi](https://www.chezmoi.io/)                          | ✅🍎🤖🐧🪟⌨📖               | Dot files syncing tool                                                                                                               |
-| zsh                                                         | 📖✅🍎🤖🐧🪟⌨               | Default shell                                                                                                                        |
-| zellij                                                      | 📖✅🍎🤖🐧🪟⌨               | Current default multiplexer                                                                                                          |
-| tmux                                                        | 📖✅🍎🤖🐧🪟⌨               | Fall back terminal multiplexer                                                                                                       |
-| vimdiff                                                     | 📖✅🍎🤖🐧🪟⌨               | Default tui diff compare                                                                                                             |
-| vim                                                         | 📖✅🍎🤖🐧🪟⌨               | Current terminal text editor                                                                                                         |
-| Go                                                          | 📖✅🍎🤖🐧🪟                | Current favourite system language                                                                                                    |
-| Jetbrains products                                          | ✅🍎🤖🐧🪟🖱️⚠              | Favourite IDE                                                                                                                        |
-| OpenAI ChatGPT                                              | 🖱️️⚠✅                     | Got to use some sort of LLM these days                                                                                               |
-| [Suno AI](https://app.suno.ai/)                             | 🖱️️⚠                      | Great little music generator                                                                                                         |
-| [gobookmarks](https://github.com/arran4/gobookmarks)        | 🌐✅📖                      | My "homepage" bookmark system which I had used on and off since the late 90s in various capacities                                   |
-| [duf](https://github.com/muesli/duf)                        | 📖✅🍎🐧🪟⌨                 | Easier to read than `df`                                                                                                             |
-| [Linkwarden](https://github.com/linkwarden/linkwarden)      | 📖✅🌐🖱️️                      | Link management, reference management and archiving self hosted service                                                              |
-| [Bitwarden](https://bitwarden.com/)                         | 📖🍎🤖🐧🪟🌐🖱️️              | Password manager - Growing stale                                                                                                     |
-| [AnyType](https://anytype.io/)                              | 📖✅🍎🤖🐧🪟🖱️️               | Note taking app                                                                                                                      |
-| [Flutter](https://flutter.dev/)                             | 📖✅🍎🤖🐧🪟🌐⚠             | Cross platform development toolkit                                                                                                   |
-| [Which Browser](http://arran4.sdf.org/which_browser/)       | ✅🍎🐧🪟⚠🖱️️                  | Link intention management app                                                                                                        |
-| [Gentoo Linux](https://www.gentoo.org/)                     | ✅🐧📖                      | Linux distribution                                                                                                                   |
-| [Dendrite](https://github.com/matrix-org/dendrite)          | 📖✅🍎🤖🐧🪟                | Matrix server - self hosted                                                                                                          |
-| [Kavita Reader](https://www.kavitareader.com/)              | 📖✅🌐                      | Self hosted comic, ebook, etc reader (webbased)                                                                                      |
-| [Gitlab](https://about.gitlab.com/)                         | 📖✅🌐                      | Self hosted Git service                                                                                                              |
-| [Omnivore](https://omnivore.app)                            | ⚠🌐                        | Read it later service                                                                                                                |
-| [Nheko](https://github.com/Nheko-Reborn/nheko)              | 📖🍎🐧🪟🖱️️                  | Matrix client for desktops                                                                                                           |
-| [Fluffy Chat](https://fluffychat.im/)                       | 📖🍎🤖🐧🪟🖱️️                | Matrix client for mobile and desktops                                                                                                |
-| [Git](https://git-scm.com/)                                 | 📖✅🌐                      | Version control system                                                                                                               |
-| [Synology Audio Station](https://www.synology.com/en-us)    | ⚠🌐🍎🤖                    | Music player and streaming product - self hosted                                                                                     |
-| [Synology Drive](https://www.synology.com/en-us)            | 🍎🤖🐧🪟🌐⚠                | Online document editing system                                                                                                       |
-| [Synology NAS](https://www.synology.com/en-us)              | ⚠🌐                        | Network attached storage                                                                                                             |
-| [Synology MailPlus](https://www.synology.com/en-us)         | 🍎🤖🐧🪟🌐⚠                | Mail server                                                                                                                          |
-| [Synology Container Manager](https://www.synology.com/en-us) | ⚠🌐                        | Docker and docker compose manager                                                                                                    |
-| [Libra Office](https://www.libreoffice.org/)                | 📖✅🍎🐧🪟                  | Local office suite                                                                                                                   |
-| [Mastodon](https://mstdn.party/)                            | 📖🌐                       | Federated Microblogging platform - self hostable                                                                                     |
-| [Lemmy](https://aussie.zone/)                               | 📖🌐                       | Federated Linksharing forum                                                                                                          |
-| [Docker](https://www.docker.com/)                           | 📖✅🍎🐧🪟                  | Containerization service                                                                                                             |
-| [7zip](https://www.7-zip.org/)                              | 📖✅🐧🪟                    | Archive extractor, viewier and creator                                                                                               |
-| [Plex](https://www.plex.tv/)                                | ✅🍎🤖🐧🪟🌐⚠🖱️️              | Self hosted media streaming service                                                                                                  |
-| [Plex Amp](https://www.plex.tv/en-au/plexamp/)              | ✅🍎🤖🪟🌐⚠🖱️️                | Self hosted music and podcast streaming service                                                                                      |
-| [Firefox](https://www.mozilla.org/en-US/firefox/)           | 📖🍎🤖🐧🪟🖱️️               | You gotta have a web-browser all of them plainly suck, the reason other than games and LLMs people upgrade their computers these days |
-| [Kleopatra](https://www.openpgp.org/software/kleopatra/)    | 📖🐧🪟🖱️️               | GPG certificate manager                                                                                                              |
-| [Strawberry](https://www.strawberrymusicplayer.org/)        | ✅🍎🤖🐧🪟🌐🖱️️              | Desktop Music Player                                                                                                                 |
-| [Audacious](https://audacious-media-player.org/)            | 🍎🤖🐧🪟🌐🖱️️               | Desktop Music Player - With winamp skin support                                                                                      |
-| [Uptimed](https://github.com/rpodgorny/uptimed)             | 📖✅🍎🤖🐧🪟⌨               | A (local) service that keeps a record of all your uptimes |
+# Benefits
 
-## Legend
+Using these dotfiles provides a quick way to bootstrap a consistent development
+environment across multiple platforms. Everything is driven by
+[chezmoi](https://www.chezmoi.io/) so you can apply or customize the configuration
+with a single command.
 
-| Symbol | Meaning                                            |
-|--------|----------------------------------------------------|
-| ✅      | My top choices                                     |
-| 📖     | Opensource                                         |
-| ⌨️     | CLI/TUI only                                       |
-| 🖱️️   | Desktop UI app only                                |
-| 🧐     | I have personally used and inspected this software |
-| ⚠️     | Software is proprietary                            |
-| 🕒     | Software is outdated/abandoned                     |
-| 🍎     | Available for Apple products                       |
-| 🤖     | Available for Android products                     |
-| 🐧     | Available for Linux                                |
-| 🪟     | Available for Windows                              |
-| 🌐     | Available online                                   |
+Highlights include:
 
-# Interesting tools:
+- Zsh and Bash setups with a shared prompt and a library of useful aliases (see `.chezmoitemplates`).
+- `.gitconfig.tmpl` that wires in the best available editor, color output and credential helpers.
+- Minimal tmux config with mouse mode and zsh as the default shell.
+- Example `.vimrc` and support files for Vim or Neovim.
+- OS-aware templates (`.chezmoi.toml.tmpl`) that select paths and tools based on your platform.
+- Scripts for one-time tasks such as updating the font cache.
 
-* https://github.com/tep/terminal-decor
+Feel free to copy individual pieces or adapt the whole setup to suit your needs.
+
+### Try it out
+
+1. Clone the repository and run `./install`.
+2. Open a new terminal and check the prompt, aliases and git settings.
+3. Start `tmux` to see the multiplexer configuration.
+4. Inspect `.chezmoitemplates` to learn how the templates are structured.
 
 ## Encrypting credentials with ejson
 


### PR DESCRIPTION
## Summary
- remove large Tools listing from README
- add a short Benefits section describing what these dotfiles provide
- expand highlights with specific components and a quick "Try it out" guide

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68523553e300832fbc2cbf21891476d9