### PR TITLE
Add interactive macOS defaults script

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -147,6 +147,7 @@
 
 {{ if ne .chezmoi.os "darwin" }}
 /bin/executable_screenshot-location_mac.sh
+/.local/bin/macos_defaults.sh
 {{ end }}
 
 {{ if ne .chezmoi.os "windows" }}

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Apply macOS defaults for Dock, Finder and screenshots
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "Not macOS. Skipping macOS defaults."
+  exit 0
+fi
+
+printf "Apply macOS defaults now? [y/N] "
+read -r answer
+case "$answer" in
+  y|Y|yes|YES)
+    ;;
+  *)
+    echo "Skipping macOS defaults."
+    exit 0
+    ;;
+esac
+
+# Dock: auto hide and disable recent apps
+defaults write com.apple.dock autohide -bool true
+defaults write com.apple.dock show-recents -bool false
+
+# Finder: show path bar and status bar
+defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder ShowStatusBar -bool true
+
+# Save screenshots to a dedicated directory
+screenshots_dir="${HOME}/Screenshots/mac defaults"
+mkdir -p "$screenshots_dir"
+defaults write com.apple.screencapture location "$screenshots_dir"
+
+# Restart affected services
+killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- prompt before running macOS defaults script
- ignore the script on non-macOS hosts
- fix ignore location for macOS defaults script

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_685220265954832f86b7c5b9e95e7175