### PR TITLE
Add sdk/flutter path to binroots

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -33,7 +33,7 @@
         {{- $usrbins = (list "games" ) -}}
         {{- $usrlocalbins = (list) -}}
   {{- $binpaths = (list (joinPath .chezmoi.homeDir "/.dotnet/tools" ) ) -}}
-        {{- $binroots = (list "/" "/usr/" "/usr/local/" .chezmoi.homeDir (joinPath .chezmoi.homeDir "/.local" ) (joinPath .chezmoi.homeDir "/go" ) (joinPath .chezmoi.homeDir "/.go/path" ) (joinPath .chezmoi.homeDir "/libs/flutter" ) (joinPath .chezmoi.homeDir "/.pub-cache" ) (joinPath .chezmoi.homeDir "/.cache/npm" ) ) -}}
+        {{- $binroots = (list "/" "/usr/" "/usr/local/" .chezmoi.homeDir (joinPath .chezmoi.homeDir "/.local" ) (joinPath .chezmoi.homeDir "/go" ) (joinPath .chezmoi.homeDir "/.go/path" ) (joinPath .chezmoi.homeDir "/libs/flutter" ) (joinPath .chezmoi.homeDir "/sdk/flutter" ) (joinPath .chezmoi.homeDir "/.pub-cache" ) (joinPath .chezmoi.homeDir "/.cache/npm" ) ) -}}
         {{- $terminfosearch = (list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" ) -}}
         {{- $termfallback = (list "rxvt" "xterm" "linux" "vt100" ) -}}
 #{{ else if eq .chezmoi.os "windows" }} Windows


### PR DESCRIPTION
## Summary
- include `sdk/flutter` in the binroots list

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6852c7da60d0832f8482b833db66c4e5