### PR TITLE
Update prompt template to display history line number

### DIFF
--- a/.chezmoitemplates/prompt.tmpl
+++ b/.chezmoitemplates/prompt.tmpl
@@ -22,15 +22,15 @@ if test "$(id -u)" -eq 0; then
 fi
 
   {{ if eq $shell "zsh" }}
-export SPROMPT="Potential spelling error %R , could be %r"
-export PROMPT='%n@%m:%~ '"${ctx}
+  export SPROMPT="Potential spelling error %R , could be %r"
+  export PROMPT='%n@%m:%~ %h '"${ctx}
 ${pchar} "
   {{- else if eq $shell "bash" }}
-export PS1='\u@\h:\w '"${ctx}\n${pchar} "
+  export PS1='\u@\h:\w \! '"${ctx}\n${pchar} "
   {{- else if eq $shell "ksh" }}
-export PS1='${USER}@$(hostname -s):${PWD} '"${ctx}\n${pchar} "
+  export PS1='${USER}@$(hostname -s):${PWD} ! '"${ctx}\n${pchar} "
   {{- else if eq $shell "tcsh" }}
-set prompt="%n@%m:%~ ${ctx}\n${pchar} "
+  set prompt="%n@%m:%~ %h ${ctx}\n${pchar} "
   {{- end }}
 unset ctx pchar
 {{- else }}


### PR DESCRIPTION
## Summary
- show command history number in the shell prompt for bash, zsh, ksh and tcsh

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68534465e420832f98d548f922499d4c