### PR TITLE
Correct .local/bin ignore logic

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -130,7 +130,9 @@
 /.editorconfig
 /.config/pulse
 /.config/gcloud
+{{ if eq .chezmoi.os "windows" }}
 /.local/bin
+{{ end }}
 /.local/include
 /.local/lib
 


### PR DESCRIPTION
## Summary
- skip `~/.local/bin` only when the OS is Windows
- keep `macos_defaults.sh` excluded except on Darwin

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_685346f55760832fbae452af2194ca70