### PR TITLE
Add GPG key generation script

### DIFF
--- a/run_once_generate-gpg-key.sh
+++ b/run_once_generate-gpg-key.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# Determine git user email
+email=$(git config --get user.email || true)
+if [ -z "$email" ]; then
+  exit 0
+fi
+
+# Check for gpg executable
+if ! command -v gpg >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Check if a secret key already exists for this email
+if gpg --list-secret-keys "$email" >/dev/null 2>&1; then
+  exit 0
+fi
+
+name=$(git config --get user.name || echo "$email")
+
+gpg --batch --generate-key <<KEY
+Key-Type: default
+Subkey-Type: default
+Name-Real: $name
+Name-Email: $email
+Expire-Date: 0
+%no-protection
+%commit
+KEY
+


### PR DESCRIPTION
## Summary
- add `run_once_generate-gpg-key.sh` to auto-create a GPG key if needed

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_6853a4d0e288832f899973ad27a9a973