### PR TITLE
Add gpg-agent SSH integration

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -115,6 +115,7 @@
 /.gdrive
 /.gitlab
 /.gnupg
+!/.gnupg/gpg-agent.conf
 /.googlecl
 /.hushlogin
 /.kde

--- a/.chezmoitemplates/gpg-agent-ssh.tmpl
+++ b/.chezmoitemplates/gpg-agent-ssh.tmpl
@@ -1,0 +1,11 @@
+{{- $shell := index . "shell" -}}
+{{- if eq $shell "tcsh" }}
+if ( $?prompt ) then
+  setenv SSH_AUTH_SOCK `gpgconf --list-dirs agent-ssh-socket`
+endif
+{{- else }}
+if command -v gpgconf >/dev/null 2>&1; then
+  SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+  export SSH_AUTH_SOCK
+fi
+{{- end }}

--- a/README.md
+++ b/README.md
@@ -127,3 +127,9 @@ Host legacy.example.com
   IdentitiesOnly no
 ```
 
+## GPG agent with SSH support
+
+`dot_gnupg/gpg-agent.conf` installs `enable-ssh-support` so `gpg-agent` can act
+as your SSH agent. Login scripts export `SSH_AUTH_SOCK` from
+`gpgconf --list-dirs agent-ssh-socket` to point SSH at the agent's socket.
+

--- a/dot_bash_login.tmpl
+++ b/dot_bash_login.tmpl
@@ -11,3 +11,4 @@ else
 fi
 
 # SSH Agent if required
+{{ template "gpg-agent-ssh.tmpl" deepCopy $ | merge (dict "shell" "bash") }}

--- a/dot_gnupg/gpg-agent.conf
+++ b/dot_gnupg/gpg-agent.conf
@@ -1,0 +1,1 @@
+enable-ssh-support

--- a/dot_zlogin.tmpl
+++ b/dot_zlogin.tmpl
@@ -4,3 +4,4 @@
 
 
 # SSH Agent if required
+{{ template "gpg-agent-ssh.tmpl" deepCopy $ | merge (dict "shell" "zsh") }}


### PR DESCRIPTION
## Summary
- store gpg-agent.conf with `enable-ssh-support`
- expose gpg-agent's SSH socket via new template
- set SSH_AUTH_SOCK from login scripts
- document gpg-agent setup with SSH in README
- unignore gpg-agent.conf in .chezmoiignore

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6854da710914832fb2d6b6ebb3a2fa2e