### PR TITLE
Add dot_shinit template

### DIFF
--- a/dot_shinit.tmpl
+++ b/dot_shinit.tmpl
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Load common login settings
+{{ template "shell-login-common.tmpl" deepCopy $ | merge (dict "shell" "sh") }}
+
+# History configuration
+HISTFILE="$HOME/.sh_history"
+HISTSIZE=32768
+export HISTFILE HISTSIZE
+
+# Editor and pager
+export VISUAL=vi
+export EDITOR=vi
+export PAGER=less
+
+# Basic aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+{{ template "path-discovery.tmpl" $ }}
+{{ template "common-misc-env.tmpl" $ }}
+
+return # This prevents scripts which append their own installers from "working"


### PR DESCRIPTION
## Summary
- add new `dot_shinit.tmpl` for generic POSIX shell initialization

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6854da703b5c832f9c084dabbcce40f9