### PR TITLE
Ignore GH release script when CLI absent

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -152,6 +152,10 @@
 /.local/bin/macos_defaults.sh
 {{ end }}
 
+{{ if not (lookPath "gh") }}
+/.local/bin/gh-release.sh
+{{ end }}
+
 {{ if ne .chezmoi.os "windows" }}
 /Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
 /bin/*.cmd

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Highlights include:
 - Example `.vimrc` and support files for Vim or Neovim.
 - OS-aware templates (`.chezmoi.toml.tmpl`) that select paths and tools based on your platform.
 - Scripts for one-time tasks such as updating the font cache.
+- Conditional `.chezmoiignore` rules skip local executables like
+  `gh-release.sh` when dependencies such as the GitHub CLI (`gh`) are absent.
 
 Feel free to copy individual pieces or adapt the whole setup to suit your needs.
 


### PR DESCRIPTION
## Summary
- mention conditional ignore of local executables in README
- skip `~/.local/bin/gh-release.sh` when the `gh` CLI isn't available

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_6859f9152240832fb0b82b9301a5c580