### PR TITLE
Template app version checks

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -315,6 +315,11 @@
         digLocation="{{$digLocation}}"
         xinputLocation="{{$xinputLocation}}"
         chromeLocation="{{$chromeLocation}}"
+        minGitVersion="2.45.1"
+        minZshVersion="5.9"
+        minTmuxVersion="3.3a"
+        minVimVersion="9.1"
+        minNvimVersion="0.9.5"
         # Timestamp of when chezmoi templates were last processed. Defined here
         # so it remains constant across templated files and prevents noisy diffs
         # when regenerating dotfiles.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Feel free to copy individual pieces or adapt the whole setup to suit your needs.
 ### Try it out
 
 1. Clone the repository and run `./install`.
-2. Open a new terminal and check the prompt, aliases and git settings.
-3. Start `tmux` to see the multiplexer configuration.
-4. Inspect `.chezmoitemplates` to learn how the templates are structured.
+2. Version checks run during setup using a PATH built from the `paths` defined in `.chezmoi.toml.tmpl` and warn only when a tool is older than the listed minimum version or the comparison fails.
+3. Open a new terminal and check the prompt, aliases and git settings.
+4. Start `tmux` to see the multiplexer configuration.
+5. Inspect `.chezmoitemplates` to learn how the templates are structured.
 
 ## Encrypting credentials with ejson
 

--- a/run_once_check-app-versions.sh.tmpl
+++ b/run_once_check-app-versions.sh.tmpl
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+# Build PATH from template variables so version checks find installed tools
+{{ template "path-discovery.tmpl" $ }}
+
+check_version() {
+  command="$1"
+  minimum="$2"
+  args="$3"
+  if command -v "$command" >/dev/null 2>&1; then
+    out=$($command $args 2>&1 | head -n 1 | tr -d '\r')
+    installed=$(echo "$out" | grep -o '[0-9][0-9.]*[0-9]' | head -n 1)
+    [ -z "$installed" ] && return
+    result=$(awk -v inst="$installed" -v min="$minimum" '
+      function split_nums(str, arr,  n,i,j) {
+        n = split(str, tmp, /[^0-9]+/); j = 0;
+        for (i = 1; i <= n; i++) if (tmp[i] != "") arr[++j] = tmp[i];
+        return j;
+      }
+      BEGIN {
+        ic = split_nums(inst, ia); mc = split_nums(min, ma);
+        len = (ic > mc ? ic : mc);
+        for (i = 1; i <= len; i++) {
+          if (i > ic || i > mc) { print "cmpfail"; exit }
+          if (ia[i] + 0 < ma[i] + 0) { print "less"; exit }
+          if (ia[i] + 0 > ma[i] + 0) { print "greater"; exit }
+        }
+        print "equal";
+      }')
+    case "$result" in
+      less)
+        echo "$command version $installed is older than the recommended $minimum"
+        ;;
+      cmpfail)
+        echo "Could not determine if $command version $installed meets recommended $minimum"
+        ;;
+    esac
+  fi
+}
+
+check_version git {{ .minGitVersion }} "--version"
+check_version zsh {{ .minZshVersion }} "--version"
+check_version tmux {{ .minTmuxVersion }} "-V"
+check_version vim {{ .minVimVersion }} "--version"
+check_version nvim {{ .minNvimVersion }} "--version"
+


### PR DESCRIPTION
## Summary
- reference minimum versions from `.chezmoi.toml.tmpl`
- make `run_once_check-app-versions.sh` warn when below the minimum
- note in README that version checks rely on PATH and minimum versions
- load PATH for version checks from template paths
- compare version numbers component-wise and only warn if installed is older or comparison fails

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_685f716d29bc832fbd0c29a8c500e315