### PR TITLE
Fix variable access in version check script

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -89,7 +89,7 @@
 {{- if ne .chezmoi.os "windows" -}}
   {{- range $prefix := list "libs" "sdk" -}}
     {{- range $tool := list "go" "flutter" -}}
-      {{- $root := joinPath .chezmoi.homeDir $prefix $tool -}}
+      {{- $root := joinPath $.chezmoi.homeDir $prefix $tool -}}
       {{- if stat (joinPath $root "bin") -}}
         {{- $binroots = append $binroots $root -}}
       {{- end -}}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,7 +1,7 @@
 {{- $isWsl := or (env "WSL_DISTRO_NAME") (env "IS_WSL") | not | not -}}
 {{- $isDevcontainer := or (env "REMOTE_CONTAINERS") (env "CODESPACES") (env "VSCODE_REMOTE_CONTAINERS_SESSION") | not | not -}}
 {{- $isGnome := lookPath "gnome-shell" | not | not -}}
-{{- $hasHomeGPG := not ( kindIs "boolean" ( stat (joinPath .chezmoi.homeDir ".gnupg/private-keys-v1.d" ) ) ) -}}
+{{- $hasHomeGPG := not ( kindIs "boolean" ( stat (joinPath .homeDir ".gnupg/private-keys-v1.d" ) ) ) -}}
 {{- $headlessGuess := ( or $isWsl (not (or ( env "DISPLAY" ) (eq .chezmoi.os "windows" ) ) ) ) -}}
 {{- $gpgconfiguredGuess := $hasHomeGPG -}}
 {{- $headless := promptBool "headless" $headlessGuess -}}
@@ -21,14 +21,14 @@
         {{- $binroots = list
           "/"
           "/usr/"
-          .chezmoi.homeDir
-          (joinPath .chezmoi.homeDir "/.local")
-          (joinPath .chezmoi.homeDir "/go")
-          (joinPath .chezmoi.homeDir "/Library/flutter")
-          (joinPath .chezmoi.homeDir "/.pub-cache")
-          (joinPath .chezmoi.homeDir "/.cache/npm")
+          .homeDir
+          (joinPath .homeDir "/.local")
+          (joinPath .homeDir "/go")
+          (joinPath .homeDir "/Library/flutter")
+          (joinPath .homeDir "/.pub-cache")
+          (joinPath .homeDir "/.cache/npm")
         -}}
-        {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
+        {{- $paths = append $paths (joinPath .homeDir "/.dotnet/tools") -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "xterm" "linux" "vt100" -}}
 #{{ else if eq .chezmoi.os "linux" }} Linux
@@ -36,16 +36,16 @@
           "/"
           "/usr/"
           "/usr/local/"
-          .chezmoi.homeDir
-          (joinPath .chezmoi.homeDir "/.local")
-          (joinPath .chezmoi.homeDir "/go")
-          (joinPath .chezmoi.homeDir "/.go/path")
-          (joinPath .chezmoi.homeDir "/libs/flutter")
-          (joinPath .chezmoi.homeDir "/sdk/flutter")
-          (joinPath .chezmoi.homeDir "/.pub-cache")
-          (joinPath .chezmoi.homeDir "/.cache/npm")
+          .homeDir
+          (joinPath .homeDir "/.local")
+          (joinPath .homeDir "/go")
+          (joinPath .homeDir "/.go/path")
+          (joinPath .homeDir "/libs/flutter")
+          (joinPath .homeDir "/sdk/flutter")
+          (joinPath .homeDir "/.pub-cache")
+          (joinPath .homeDir "/.cache/npm")
         -}}
-        {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
+        {{- $paths = append $paths (joinPath .homeDir "/.dotnet/tools") -}}
         {{- $paths = append $paths "/usr/games/bin" -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "rxvt" "xterm" "linux" "vt100" -}}
@@ -54,7 +54,7 @@
         {{- $programFilesX86 := (env "ProgramFiles(x86)" | default "C:/Program Files (x86)") -}}
         {{- $systemRoot := (env "SystemRoot" | default "C:/Windows") -}}
         {{- $binroots = list $programFiles $programFilesX86 $systemRoot (joinPath $systemRoot "System32") -}}
-        {{- $paths = append $paths (joinPath .chezmoi.homeDir "AppData/Local/Microsoft/WindowsApps") -}}
+        {{- $paths = append $paths (joinPath .homeDir "AppData/Local/Microsoft/WindowsApps") -}}
         {{- $terminfosearch = list -}}
         {{- $termfallback = list "linux" "vt100" -}}
         {{- $gpgLocation = joinPath $programFilesX86 "GnuPG/bin/gpg.exe" -}}
@@ -62,11 +62,11 @@
         {{- $binroots = list
           "/"
           "/usr/"
-          .chezmoi.homeDir
-          (joinPath .chezmoi.homeDir "/.local")
-          (joinPath .chezmoi.homeDir "/go")
+          .homeDir
+          (joinPath .homeDir "/.local")
+          (joinPath .homeDir "/go")
         -}}
-        {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
+        {{- $paths = append $paths (joinPath .homeDir "/.dotnet/tools") -}}
         {{- range list "httrack" "SUNWsneep" "test" "VRTSvxvm" "SUNWvts" "SUNWexplo" "VRTS" "VRTSob" -}}
           {{- $paths = append $paths (joinPath "/opt" . "/bin") -}}
         {{- end -}}
@@ -87,9 +87,9 @@
 #{{ end }} End OS Specific code
 
 {{- if ne .chezmoi.os "windows" -}}
-  {{- range $prefix := list "libs" "sdk" -}}
-    {{- range $tool := list "go" "flutter" -}}
-      {{- $root := joinPath $.chezmoi.homeDir $prefix $tool -}}
+  {{- range $pidx, $prefix := list "libs" "sdk" -}}
+    {{- range $tidx, $tool := list "go" "flutter" -}}
+      {{- $root := joinPath $.homeDir $prefix $tool -}}
       {{- if stat (joinPath $root "bin") -}}
         {{- $binroots = append $binroots $root -}}
       {{- end -}}
@@ -106,8 +106,8 @@
 
 {{- $gitCredentialManagerLocation := findExecutable "git-credential-manager" $paths -}}
 {{- $gitCredentialOAuthLocation := "" -}}
-{{- if stat (joinPath .chezmoi.homeDir "/.local/bin/git-credential-oauth") -}}
-  {{- $gitCredentialOAuthLocation = joinPath .chezmoi.homeDir "/.local/bin/git-credential-oauth" -}}
+{{- if stat (joinPath .homeDir "/.local/bin/git-credential-oauth") -}}
+  {{- $gitCredentialOAuthLocation = joinPath .homeDir "/.local/bin/git-credential-oauth" -}}
 {{- else -}}
   {{- $gitCredentialOAuthLocation = findExecutable "git-credential-oauth" $paths -}}
   {{- if eq $gitCredentialOAuthLocation "" -}}
@@ -159,8 +159,8 @@
   {{- $goLocation = lookPath "go" -}}
 {{- end -}}
 {{- $ghLocation := "" -}}
-{{- if stat (joinPath .chezmoi.homeDir "/.local/bin/gh") -}}
-  {{- $ghLocation = joinPath .chezmoi.homeDir "/.local/bin/gh" -}}
+{{- if stat (joinPath .homeDir "/.local/bin/gh") -}}
+  {{- $ghLocation = joinPath .homeDir "/.local/bin/gh" -}}
 {{- else -}}
   {{- $ghLocation = findExecutable "gh" $paths -}}
   {{- if eq $ghLocation "" -}}
@@ -169,8 +169,8 @@
 {{- end -}}
 
 {{- $gitTagIncLocation := "" -}}
-{{- if stat (joinPath .chezmoi.homeDir "/.local/bin/git-tag-inc") -}}
-  {{- $gitTagIncLocation = joinPath .chezmoi.homeDir "/.local/bin/git-tag-inc" -}}
+{{- if stat (joinPath .homeDir "/.local/bin/git-tag-inc") -}}
+  {{- $gitTagIncLocation = joinPath .homeDir "/.local/bin/git-tag-inc" -}}
 {{- else -}}
   {{- $gitTagIncLocation = findExecutable "git-tag-inc" $paths -}}
   {{- if eq $gitTagIncLocation "" -}}

--- a/.chezmoitemplates/check-app-versions.tmpl
+++ b/.chezmoitemplates/check-app-versions.tmpl
@@ -1,0 +1,44 @@
+# Build PATH from template variables so version checks find installed tools
+{{ template "path-discovery.tmpl" $ }}
+
+check_version() {
+  command="$1"
+  minimum="$2"
+  args="$3"
+  if command -v "$command" >/dev/null 2>&1; then
+    out=$($command $args 2>&1 | head -n 1 | tr -d '\r')
+    installed=$(echo "$out" | grep -o '[0-9][0-9.]*[0-9]' | head -n 1)
+    [ -z "$installed" ] && return
+    result=$(awk -v inst="$installed" -v min="$minimum" '
+      function split_nums(str, arr,  n,i,j) {
+        n = split(str, tmp, /[^0-9]+/); j = 0;
+        for (i = 1; i <= n; i++) if (tmp[i] != "") arr[++j] = tmp[i];
+        return j;
+      }
+      BEGIN {
+        ic = split_nums(inst, ia); mc = split_nums(min, ma);
+        len = (ic > mc ? ic : mc);
+        for (i = 1; i <= len; i++) {
+          if (i > ic || i > mc) { print "cmpfail"; exit }
+          if (ia[i] + 0 < ma[i] + 0) { print "less"; exit }
+          if (ia[i] + 0 > ma[i] + 0) { print "greater"; exit }
+        }
+        print "equal";
+      }')
+    case "$result" in
+      less)
+        echo "$command version $installed is older than the recommended $minimum"
+        ;;
+      cmpfail)
+        echo "Could not determine if $command version $installed meets recommended $minimum"
+        ;;
+    esac
+  fi
+}
+
+check_version git {{ index $ "minGitVersion" }} "--version"
+check_version zsh {{ index $ "minZshVersion" }} "--version"
+check_version tmux {{ index $ "minTmuxVersion" }} "-V"
+check_version vim {{ index $ "minVimVersion" }} "--version"
+check_version nvim {{ index $ "minNvimVersion" }} "--version"
+

--- a/run_once_check-app-versions.sh.tmpl
+++ b/run_once_check-app-versions.sh.tmpl
@@ -39,9 +39,9 @@ check_version() {
   fi
 }
 
-check_version git {{ index $ "minGitVersion" }} "--version"
-check_version zsh {{ index $ "minZshVersion" }} "--version"
-check_version tmux {{ index $ "minTmuxVersion" }} "-V"
-check_version vim {{ index $ "minVimVersion" }} "--version"
-check_version nvim {{ index $ "minNvimVersion" }} "--version"
+check_version git {{ index . "minGitVersion" }} "--version"
+check_version zsh {{ index . "minZshVersion" }} "--version"
+check_version tmux {{ index . "minTmuxVersion" }} "-V"
+check_version vim {{ index . "minVimVersion" }} "--version"
+check_version nvim {{ index . "minNvimVersion" }} "--version"
 

--- a/run_once_check-app-versions.sh.tmpl
+++ b/run_once_check-app-versions.sh.tmpl
@@ -39,9 +39,9 @@ check_version() {
   fi
 }
 
-check_version git {{ .minGitVersion }} "--version"
-check_version zsh {{ .minZshVersion }} "--version"
-check_version tmux {{ .minTmuxVersion }} "-V"
-check_version vim {{ .minVimVersion }} "--version"
-check_version nvim {{ .minNvimVersion }} "--version"
+check_version git {{ index $ "minGitVersion" }} "--version"
+check_version zsh {{ index $ "minZshVersion" }} "--version"
+check_version tmux {{ index $ "minTmuxVersion" }} "-V"
+check_version vim {{ index $ "minVimVersion" }} "--version"
+check_version nvim {{ index $ "minNvimVersion" }} "--version"
 

--- a/run_once_check-app-versions.sh.tmpl
+++ b/run_once_check-app-versions.sh.tmpl
@@ -1,47 +1,6 @@
 #!/bin/sh
 set -e
 
-# Build PATH from template variables so version checks find installed tools
-{{ template "path-discovery.tmpl" $ }}
+{{ template "check-app-versions.tmpl" $ }}
 
-check_version() {
-  command="$1"
-  minimum="$2"
-  args="$3"
-  if command -v "$command" >/dev/null 2>&1; then
-    out=$($command $args 2>&1 | head -n 1 | tr -d '\r')
-    installed=$(echo "$out" | grep -o '[0-9][0-9.]*[0-9]' | head -n 1)
-    [ -z "$installed" ] && return
-    result=$(awk -v inst="$installed" -v min="$minimum" '
-      function split_nums(str, arr,  n,i,j) {
-        n = split(str, tmp, /[^0-9]+/); j = 0;
-        for (i = 1; i <= n; i++) if (tmp[i] != "") arr[++j] = tmp[i];
-        return j;
-      }
-      BEGIN {
-        ic = split_nums(inst, ia); mc = split_nums(min, ma);
-        len = (ic > mc ? ic : mc);
-        for (i = 1; i <= len; i++) {
-          if (i > ic || i > mc) { print "cmpfail"; exit }
-          if (ia[i] + 0 < ma[i] + 0) { print "less"; exit }
-          if (ia[i] + 0 > ma[i] + 0) { print "greater"; exit }
-        }
-        print "equal";
-      }')
-    case "$result" in
-      less)
-        echo "$command version $installed is older than the recommended $minimum"
-        ;;
-      cmpfail)
-        echo "Could not determine if $command version $installed meets recommended $minimum"
-        ;;
-    esac
-  fi
-}
-
-check_version git {{ index . "minGitVersion" }} "--version"
-check_version zsh {{ index . "minZshVersion" }} "--version"
-check_version tmux {{ index . "minTmuxVersion" }} "-V"
-check_version vim {{ index . "minVimVersion" }} "--version"
-check_version nvim {{ index . "minNvimVersion" }} "--version"
 


### PR DESCRIPTION
## Summary
- handle access to version data in `run_once_check-app-versions.sh.tmpl`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: can't evaluate field chezmoi)*

------
https://chatgpt.com/codex/tasks/task_e_685f818dcc54832fb8b531bd2d959e97