### PR TITLE
Fix homeDir reference in version check range

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -87,9 +87,9 @@
 #{{ end }} End OS Specific code
 
 {{- if ne .chezmoi.os "windows" -}}
-  {{- range $prefix := list "libs" "sdk" -}}
-    {{- range $tool := list "go" "flutter" -}}
-      {{- $root := joinPath .chezmoi.homeDir $prefix $tool -}}
+  {{- range $pidx, $prefix := list "libs" "sdk" -}}
+    {{- range $tidx, $tool := list "go" "flutter" -}}
+      {{- $root := joinPath $.chezmoi.homeDir $prefix $tool -}}
       {{- if stat (joinPath $root "bin") -}}
         {{- $binroots = append $binroots $root -}}
       {{- end -}}

--- a/.chezmoitemplates/check-app-versions.tmpl
+++ b/.chezmoitemplates/check-app-versions.tmpl
@@ -1,0 +1,44 @@
+# Build PATH from template variables so version checks find installed tools
+{{ template "path-discovery.tmpl" $ }}
+
+check_version() {
+  command="$1"
+  minimum="$2"
+  args="$3"
+  if command -v "$command" >/dev/null 2>&1; then
+    out=$($command $args 2>&1 | head -n 1 | tr -d '\r')
+    installed=$(echo "$out" | grep -o '[0-9][0-9.]*[0-9]' | head -n 1)
+    [ -z "$installed" ] && return
+    result=$(awk -v inst="$installed" -v min="$minimum" '
+      function split_nums(str, arr,  n,i,j) {
+        n = split(str, tmp, /[^0-9]+/); j = 0;
+        for (i = 1; i <= n; i++) if (tmp[i] != "") arr[++j] = tmp[i];
+        return j;
+      }
+      BEGIN {
+        ic = split_nums(inst, ia); mc = split_nums(min, ma);
+        len = (ic > mc ? ic : mc);
+        for (i = 1; i <= len; i++) {
+          if (i > ic || i > mc) { print "cmpfail"; exit }
+          if (ia[i] + 0 < ma[i] + 0) { print "less"; exit }
+          if (ia[i] + 0 > ma[i] + 0) { print "greater"; exit }
+        }
+        print "equal";
+      }')
+    case "$result" in
+      less)
+        echo "$command version $installed is older than the recommended $minimum"
+        ;;
+      cmpfail)
+        echo "Could not determine if $command version $installed meets recommended $minimum"
+        ;;
+    esac
+  fi
+}
+
+check_version git {{ .minGitVersion }} "--version"
+check_version zsh {{ .minZshVersion }} "--version"
+check_version tmux {{ .minTmuxVersion }} "-V"
+check_version vim {{ .minVimVersion }} "--version"
+check_version nvim {{ .minNvimVersion }} "--version"
+

--- a/run_once_check-app-versions.sh.tmpl
+++ b/run_once_check-app-versions.sh.tmpl
@@ -1,47 +1,6 @@
 #!/bin/sh
 set -e
 
-# Build PATH from template variables so version checks find installed tools
-{{ template "path-discovery.tmpl" $ }}
+{{ template "check-app-versions.tmpl" $ }}
 
-check_version() {
-  command="$1"
-  minimum="$2"
-  args="$3"
-  if command -v "$command" >/dev/null 2>&1; then
-    out=$($command $args 2>&1 | head -n 1 | tr -d '\r')
-    installed=$(echo "$out" | grep -o '[0-9][0-9.]*[0-9]' | head -n 1)
-    [ -z "$installed" ] && return
-    result=$(awk -v inst="$installed" -v min="$minimum" '
-      function split_nums(str, arr,  n,i,j) {
-        n = split(str, tmp, /[^0-9]+/); j = 0;
-        for (i = 1; i <= n; i++) if (tmp[i] != "") arr[++j] = tmp[i];
-        return j;
-      }
-      BEGIN {
-        ic = split_nums(inst, ia); mc = split_nums(min, ma);
-        len = (ic > mc ? ic : mc);
-        for (i = 1; i <= len; i++) {
-          if (i > ic || i > mc) { print "cmpfail"; exit }
-          if (ia[i] + 0 < ma[i] + 0) { print "less"; exit }
-          if (ia[i] + 0 > ma[i] + 0) { print "greater"; exit }
-        }
-        print "equal";
-      }')
-    case "$result" in
-      less)
-        echo "$command version $installed is older than the recommended $minimum"
-        ;;
-      cmpfail)
-        echo "Could not determine if $command version $installed meets recommended $minimum"
-        ;;
-    esac
-  fi
-}
-
-check_version git {{ .minGitVersion }} "--version"
-check_version zsh {{ .minZshVersion }} "--version"
-check_version tmux {{ .minTmuxVersion }} "-V"
-check_version vim {{ .minVimVersion }} "--version"
-check_version nvim {{ .minNvimVersion }} "--version"
 


### PR DESCRIPTION
## Summary
- revert the `$homeDir` variable and use `.chezmoi.homeDir` directly
- keep version check logic in a shared template
- access the root context in nested range loops when checking for go and flutter paths

## Testing
- `bin/chezmoi execute-template --init < .chezmoi.toml.tmpl >/tmp/out.toml`
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: can't evaluate field chezmoi)*

------
https://chatgpt.com/codex/tasks/task_e_685f818dcc54832fb8b531bd2d959e97