### PR TITLE
Fix fish prompt

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -150,6 +150,10 @@
   {{- $gitLocation = lookPath "git" -}}
 {{- end -}}
 {{- $zshLocation := findExecutable "zsh" $paths -}}
+{{- $fishLocation := findExecutable "fish" $paths -}}
+{{- if eq $fishLocation "" -}}
+  {{- $fishLocation = lookPath "fish" -}}
+{{- end -}}
 {{- $lessLocation := findExecutable "less" $paths -}}
 {{- $mvnLocation := findExecutable "mvn" $paths -}}
 {{- $zellijLocation := findExecutable "zellij" $paths -}}
@@ -267,6 +271,9 @@
 {{- if and (not (eq .chezmoi.os "windows")) (not (stat $zshLocation )) -}}
         {{- writeToStdout "Can't find zsh \n" -}}
 {{- end -}}
+{{- if and (not (eq .chezmoi.os "windows")) (not (stat $fishLocation )) -}}
+        {{- writeToStdout "Can't find fish \n" -}}
+{{- end -}}
 
 {{- if and (not (eq .chezmoi.os "windows")) (not (stat $lessLocation )) -}}
         {{- writeToStdout "Can't find less \n" -}}
@@ -346,6 +353,7 @@
         gitLocation="{{ $gitLocation }}"
         gpgLocation="{{$gpgLocation}}"
         zshLocation="{{$zshLocation}}"
+        fishLocation="{{$fishLocation}}"
         lessLocation="{{$lessLocation}}"
         mvnLocation="{{$mvnLocation}}"
         zellijLocation="{{$zellijLocation}}"
@@ -362,6 +370,7 @@
         minGitVersion="2.45.1"
         minZshVersion="5.9"
         minTmuxVersion="3.3a"
+        minFishVersion="3.6"
         minVimVersion="9.1"
         minNvimVersion="0.9.5"
         # Timestamp of when chezmoi templates were last processed. Defined here

--- a/.chezmoitemplates/check-app-versions.tmpl
+++ b/.chezmoitemplates/check-app-versions.tmpl
@@ -83,6 +83,9 @@ check_version "{{ index . "zshLocation" }}" "{{ index . "minZshVersion" }}" "--v
 {{- if (index . "tmuxLocation") }}
 check_version "{{ index . "tmuxLocation" }}" "{{ index . "minTmuxVersion" }}" "-V"
 {{- end }}
+{{- if (index . "fishLocation") }}
+check_version "{{ index . "fishLocation" }}" "{{ index . "minFishVersion" }}" "--version"
+{{- end }}
 {{- if (index . "vimLocation") }}
 check_version "{{ index . "vimLocation" }}" "{{ index . "minVimVersion" }}" "--version"
 {{- end }}

--- a/.chezmoitemplates/prompt.tmpl
+++ b/.chezmoitemplates/prompt.tmpl
@@ -1,6 +1,29 @@
 {{- $shell := index . "shell" -}}
 
-{{- if or (eq $shell "zsh") (eq $shell "bash") (eq $shell "ksh") (eq $shell "tcsh") -}}
+{{- if eq $shell "fish" -}}
+function fish_prompt
+  set -l ctx ""
+  if test -n "$TMUX"
+    set ctx "tmux"
+    if test $SHLVL -gt 2
+      set ctx "$ctx:$SHLVL"
+    end
+  else if test $SHLVL -gt 1
+    set ctx "$SHLVL"
+  end
+  if test -n "$ctx"
+    set ctx "($ctx)"
+  end
+
+  set -l pchar "$"
+  if test (id -u) -eq 0
+    set pchar "#"
+  end
+
+  set -l histnum (math (history | count))
+  printf "%s@%s:%s %s %s\n%s " $USER (hostname -s) (prompt_pwd) $histnum $ctx $pchar
+end
+{{- else if or (eq $shell "zsh") (eq $shell "bash") (eq $shell "ksh") (eq $shell "tcsh") -}}
 ctx=""
 if test -n "${TMUX}"; then
   ctx="tmux"

--- a/dot_config/fish/config.fish
+++ b/dot_config/fish/config.fish
@@ -1,0 +1,7 @@
+if status is-interactive
+  # For jumping between prompts in foot terminal
+  function mark_prompt_start --on-event fish_prompt
+    echo -en "\e]133;A\e\\"
+  end
+end
+

--- a/dot_config/fish/functions/fish_greeting.fish.tmpl
+++ b/dot_config/fish/functions/fish_greeting.fish.tmpl
@@ -1,0 +1,17 @@
+function fish_greeting
+  if test -e /etc/motd
+    if not cmp -s $HOME/.old_motd /etc/motd
+      cat /etc/motd | tee $HOME/.old_motd >/dev/null
+    end
+  end
+  echo "Shell is FISH version is $FISH_VERSION."
+  echo "System is (uname -a)"
+  echo "$USER@(hostname) Using term $TERM"
+  if test -n "$SSH_CLIENT"
+    echo "Connecting from $SSH_CLIENT"
+  end
+  if test -n "$DISPLAY"
+    echo "Display is set $DISPLAY"
+  end
+  echo "Chezmoi last generated {{ .generatedTime }}"
+end

--- a/dot_config/fish/functions/fish_prompt.fish.tmpl
+++ b/dot_config/fish/functions/fish_prompt.fish.tmpl
@@ -1,0 +1,1 @@
+{{ template "prompt.tmpl" deepCopy $ | merge (dict "shell" "fish") }}


### PR DESCRIPTION
## Summary
- centralize fish prompt with the shared template
- convert fish prompt file to a template

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6863381e5d7c832fb38d551e4108be6e