### PR TITLE
Update xinitrc to load Xresources

### DIFF
--- a/dot_xinitrc
+++ b/dot_xinitrc
@@ -8,3 +8,5 @@ if [ -d /etc/X11/xinit/xinitrc.d ]; then
   unset f
 fi
 
+[[ -f ~/.Xresources ]] && xrdb -merge ~/.Xresources
+


### PR DESCRIPTION
## Summary
- ensure `.xinitrc` loads `~/.Xresources` when present

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(failed: couldn't connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68771bc42768832f87f7a3af4e8f6c73