### PR TITLE
Add btop check on initialization

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -160,6 +160,10 @@
 {{- $mvnLocation := findExecutable "mvn" $paths -}}
 {{- $zellijLocation := findExecutable "zellij" $paths -}}
 {{- $tmuxLocation := findExecutable "tmux" $paths -}}
+{{- $btopLocation := findExecutable "btop" $paths -}}
+{{- if eq $btopLocation "" -}}
+  {{- $btopLocation = lookPath "btop" -}}
+{{- end -}}
 {{- $flutterLocation := findExecutable "flutter" $paths -}}
 {{- if eq $flutterLocation "" -}}
   {{- $flutterLocation = lookPath "flutter" -}}
@@ -250,6 +254,9 @@
 
 {{- if and (not (eq .chezmoi.os "windows")) (not (stat $tmuxLocation)) -}}
         {{- writeToStdout "Can't find tmux \n" -}}
+{{- end -}}
+{{- if and (eq .chezmoi.os "linux") (not (stat $btopLocation)) -}}
+        {{- writeToStdout "Can't find btop \n" -}}
 {{- end -}}
 
 {{- if and (eq .chezmoi.os "linux") (not $headless) (not (stat $kdiff3Location)) -}}
@@ -360,6 +367,7 @@
         mvnLocation="{{$mvnLocation}}"
         zellijLocation="{{$zellijLocation}}"
         tmuxLocation="{{$tmuxLocation}}"
+        btopLocation="{{$btopLocation}}"
         flutterLocation="{{$flutterLocation}}"
         goLocation="{{$goLocation}}"
         ghLocation="{{$ghLocation}}"
@@ -369,6 +377,7 @@
         digLocation="{{$digLocation}}"
         xinputLocation="{{$xinputLocation}}"
         chromeLocation="{{$chromeLocation}}"
+        minBtopVersion="1.2.13"
         minGitVersion="2.45.1"
         minZshVersion="5.9"
         minTmuxVersion="3.3a"

--- a/.chezmoitemplates/check-app-versions.tmpl
+++ b/.chezmoitemplates/check-app-versions.tmpl
@@ -83,6 +83,9 @@ check_version "{{ index . "zshLocation" }}" "{{ index . "minZshVersion" }}" "--v
 {{- if (index . "tmuxLocation") }}
 check_version "{{ index . "tmuxLocation" }}" "{{ index . "minTmuxVersion" }}" "-V"
 {{- end }}
+{{- if (index . "btopLocation") }}
+check_version "{{ index . "btopLocation" }}" "{{ index . "minBtopVersion" }}" "--version"
+{{- end }}
 {{- if (index . "fishLocation") }}
 check_version "{{ index . "fishLocation" }}" "{{ index . "minFishVersion" }}" "--version"
 {{- end }}


### PR DESCRIPTION
## Summary
- detect `btop` during template processing
- warn when `btop` is missing
- record `btop` path and minimum version in generated config
- check `btop` in the application version script

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_688066a4de34832f8d07189bc9440e8d