### PR TITLE
Add 7zip check

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -375,6 +375,7 @@
         minFishVersion="3.6"
         minVimVersion="9.1"
         minNvimVersion="0.9.5"
+        minSevenZipVersion="16.02"
         # Timestamp of when chezmoi templates were last processed. Defined here
         # so it remains constant across templated files and prevents noisy diffs
         # when regenerating dotfiles.

--- a/.chezmoitemplates/check-app-versions.tmpl
+++ b/.chezmoitemplates/check-app-versions.tmpl
@@ -92,4 +92,7 @@ check_version "{{ index . "vimLocation" }}" "{{ index . "minVimVersion" }}" "--v
 {{- if (index . "neovimLocation") }}
 check_version "{{ index . "neovimLocation" }}" "{{ index . "minNvimVersion" }}" "--version"
 {{- end }}
+{{- if (index . "sevenZipLocation") }}
+check_version "{{ index . "sevenZipLocation" }}" "{{ index . "minSevenZipVersion" }}" ""
+{{- end }}
 


### PR DESCRIPTION
## Summary
- check 7zip when verifying tool versions
- set a minimum 7zip version in the templates

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6880666a0614832f9e032b2285896285