### PR TITLE
Add install tool script and jq checks

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -182,6 +182,11 @@
   {{- end -}}
 {{- end -}}
 
+{{- $jqLocation := findExecutable "jq" $paths -}}
+{{- if eq $jqLocation "" -}}
+  {{- $jqLocation = lookPath "jq" -}}
+{{- end -}}
+
 {{- $gitTagIncLocation := "" -}}
 {{- if stat (joinPath .chezmoi.homeDir "/.local/bin/git-tag-inc") -}}
   {{- $gitTagIncLocation = joinPath .chezmoi.homeDir "/.local/bin/git-tag-inc" -}}
@@ -328,6 +333,10 @@
         {{- writeToStdout "Can't find dig \n" -}}
 {{- end -}}
 
+{{- if not (stat $jqLocation ) -}}
+        {{- writeToStdout "Can't find jq \n" -}}
+{{- end -}}
+
 {{- if and (eq .chezmoi.os "linux") (not (stat $xinputLocation )) -}}
         {{- writeToStdout "Can't find xinput \n" -}}
 {{- end -}}
@@ -375,6 +384,7 @@
         rarLocation="{{$rarLocation}}"
         sevenZipLocation="{{$sevenZipLocation}}"
         digLocation="{{$digLocation}}"
+        jqLocation="{{$jqLocation}}"
         xinputLocation="{{$xinputLocation}}"
         chromeLocation="{{$chromeLocation}}"
         minBtopVersion="1.2.13"
@@ -385,6 +395,7 @@
         minVimVersion="9.1"
         minNvimVersion="0.9.5"
         minSevenZipVersion="16.02"
+        minJqVersion="1.6"
         # Timestamp of when chezmoi templates were last processed. Defined here
         # so it remains constant across templated files and prevents noisy diffs
         # when regenerating dotfiles.

--- a/.chezmoitemplates/check-app-versions.tmpl
+++ b/.chezmoitemplates/check-app-versions.tmpl
@@ -98,4 +98,7 @@ check_version "{{ index . "neovimLocation" }}" "{{ index . "minNvimVersion" }}" 
 {{- if (index . "sevenZipLocation") }}
 check_version "{{ index . "sevenZipLocation" }}" "{{ index . "minSevenZipVersion" }}" ""
 {{- end }}
+{{- if (index . "jqLocation") }}
+check_version "{{ index . "jqLocation" }}" "{{ index . "minJqVersion" }}" "--version"
+{{- end }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin/chezmoi
+

--- a/bin/installtool
+++ b/bin/installtool
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") <command> [options]
+
+Commands:
+  list                    Show managed tools and installation status
+  git-credential-oauth    Install git-credential-oauth
+  git-tag-inc             Install git-tag-inc
+  gh                      Install GitHub CLI
+  flutter                 Install Flutter SDK
+
+Options:
+  -h, --help              Show this help
+  -v, --version VERSION   Specify version to install (default latest)
+USAGE
+}
+
+command="${1:-}"
+version="latest"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -v|--version)
+      shift
+      version="${1:-latest}"
+      ;;
+    list|git-credential-oauth|git-tag-inc|flutter|gh)
+      command="$1"
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$command" ]]; then
+  usage
+  exit 1
+fi
+
+install_git_credential_oauth() {
+  go install github.com/hickford/git-credential-oauth@"$version"
+}
+
+install_git_tag_inc() {
+  go install github.com/arran4/git-tag-inc@"$version"
+}
+
+install_gh() {
+  go install github.com/cli/cli/v2/cmd/gh@"$version"
+}
+
+install_flutter() {
+  channel="stable"
+  if [[ "$version" == "latest" ]]; then
+    releases=$(curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json)
+    hash=$(echo "$releases" | jq -r ".current_release.\"$channel\"")
+    version=$(echo "$releases" | jq -r ".releases[] | select(.hash==\"$hash\") | .version")
+  fi
+  url="https://storage.googleapis.com/flutter_infra_release/releases/$channel/linux/flutter_linux_${version}.tar.xz"
+  tmpdir=$(mktemp -d)
+  curl -fsSL "$url" -o "$tmpdir/flutter.tar.xz"
+  mkdir -p "$HOME/sdk"
+  tar -C "$tmpdir" -xf "$tmpdir/flutter.tar.xz"
+  rm -rf "$HOME/sdk/flutter"
+  mv "$tmpdir/flutter" "$HOME/sdk/"
+  rm -rf "$tmpdir"
+}
+
+is_installed() {
+  case "$1" in
+    git-credential-oauth)
+      command -v git-credential-oauth >/dev/null 2>&1
+      ;;
+    git-tag-inc)
+      command -v git-tag-inc >/dev/null 2>&1
+      ;;
+    gh)
+      command -v gh >/dev/null 2>&1
+      ;;
+    flutter)
+      [ -d "$HOME/sdk/flutter" ]
+      ;;
+  esac
+}
+
+cmd_list() {
+  for tool in git-credential-oauth git-tag-inc gh flutter; do
+    if is_installed "$tool"; then
+      echo "* $tool"
+    else
+      echo "  $tool"
+    fi
+  done
+}
+
+case "$command" in
+  list)
+    cmd_list
+    ;;
+  git-credential-oauth)
+    install_git_credential_oauth
+    ;;
+  git-tag-inc)
+    install_git_tag_inc
+    ;;
+  gh)
+    install_gh
+    ;;
+  flutter)
+    install_flutter
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add `installtool` helper for installing git-credential-oauth, git-tag-inc, gh and flutter
- ignore bundled chezmoi binary
- detect jq in init templates and note minimum version
- allow version check of jq in the `check-app-versions` script

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6881a466f0f0832fbc7d270036ea3278