### PR TITLE
Fix go env path templating

### DIFF
--- a/dot_config/go/env
+++ b/dot_config/go/env
@@ -1,1 +1,0 @@
-GOPATH=/home/arran/.go

--- a/dot_config/go/env.tmpl
+++ b/dot_config/go/env.tmpl
@@ -1,0 +1,1 @@
+GOPATH={{ .chezmoi.homeDir }}/.go


### PR DESCRIPTION
## Summary
- convert `~/.config/go/env` into a template
- reference the home directory dynamically

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6884ec3b337c832fbe9383e7efdae758