### PR TITLE
Ensure kwallet starts on Hyprland

### DIFF
--- a/dot_config/hypr/hyprland.conf
+++ b/dot_config/hypr/hyprland.conf
@@ -132,4 +132,5 @@ exec-once = swaybg -m fill /usr/share/backgrounds/your-wallpaper.jpg
 exec-once = dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP=hyprland
 exec-once = ~/.go/bin/clipse -listen
 exec-once = solaar -w hide
+exec-once = kded5
 exec-once = [workspace m silent] flatpak run com.spotify.Client


### PR DESCRIPTION
## Summary
- launch `kded5` when Hyprland starts so KDE apps find kwallet

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68856fc6226c832fae9e08112d691b63