### PR TITLE
Fix Go bin path

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -40,6 +40,7 @@
           (joinPath .chezmoi.homeDir "/.local")
           (joinPath .chezmoi.homeDir "/go")
           (joinPath .chezmoi.homeDir "/.go/path")
+          (joinPath .chezmoi.homeDir "/.go")
           (joinPath .chezmoi.homeDir "/libs/flutter")
           (joinPath .chezmoi.homeDir "/sdk/flutter")
           (joinPath .chezmoi.homeDir "/.pub-cache")


### PR DESCRIPTION
## Summary
- include both `~/.go/path` and `~/.go` when searching for Go binaries

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6884d795c0f0832f95d5570af83a8b56