### PR TITLE
Fix credential helper selection

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -46,27 +46,17 @@
   useHttpPath = true
 
 [credential]
-{{ $oauthHelper := (index . "gitCredentialOAuthLocation") }}
-{{ if ne $oauthHelper "" }}
+{{ if ne (index . "gitCredentialOAuthLocation") "" }}
   helper = cache --timeout 5184000 # 60 days
   {{ if index . "headless" }}
   helper = oauth -device
   {{ else }}
   helper = oauth
   {{ end }}
-{{ end }}
-{{ if index . "headless" }}
-        credentialStore = cache
-        cacheOptions = "--timeout 5184000"
-        helper = {{ index $ "gitCredentialManagerLocation" }}
-{{ else if eq .chezmoi.os "linux" }}
-  {{ if eq .chezmoi.osRelease.id "ubuntu" }}
-         credentialStore = secretservice
-         helper = {{ index $ "gitCredentialManagerLocation" }}
-  {{ else if eq .chezmoi.osRelease.id "gentoo" }}
-         credentialStore = secretservice
-         helper = {{ index $ "gitCredentialManagerLocation" }}
-  {{ end}}
+{{ else if ne (index . "gitCredentialManagerLocation") "" }}
+  credentialStore = cache
+  cacheOptions = "--timeout 5184000"
+  helper = {{ index $ "gitCredentialManagerLocation" }}
 {{ else }}
   helper = manager
 {{ end }}


### PR DESCRIPTION
## Summary
- simplify git credential helper logic

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_688576898c24832f8c31528bc038f216