### PR TITLE
Update path discovery for flatpak

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -47,6 +47,8 @@
           (joinPath .chezmoi.homeDir "/.cache/npm")
         -}}
         {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
+        {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.local/share/flatpak/exports/bin") -}}
+        {{- $paths = append $paths "/var/lib/flatpak/exports/bin" -}}
         {{- $paths = append $paths "/usr/games/bin" -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "rxvt" "xterm" "linux" "vt100" -}}


### PR DESCRIPTION
## Summary
- add Flatpak export directories to PATH discovery list

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_688584412368832f861b6f82952c0361