### PR TITLE
Update path discovery for Bitwarden

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -48,6 +48,7 @@
         -}}
         {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
         {{- $paths = append $paths "/usr/games/bin" -}}
+        {{- $paths = append $paths "/opt/Bitwarden" -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "rxvt" "xterm" "linux" "vt100" -}}
 #{{ else if eq .chezmoi.os "windows" }} Windows


### PR DESCRIPTION
## Summary
- include `/opt/Bitwarden` in the paths list for PATH discovery

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_688584273170832f94328f5fbbe0b841