### PR TITLE
Fix template redirection

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -289,7 +289,7 @@
 {{- if eq $clipseLocation "" -}}
         {{- writeToStdout "Can't find clipse (run installtool clipse) \n" -}}
 {{- else -}}
-        {{- $clipseVersion := trim (output $clipseLocation "--version" 2>/dev/null) -}}
+        {{- $clipseVersion := trim (output "sh" "-c" (printf "%s --version 2>/dev/null" $clipseLocation)) -}}
         {{- if eq $clipseVersion "" -}}
                 {{- writeToStdout (printf "clipse installed at %s\n" $clipseLocation) -}}
         {{- else -}}


### PR DESCRIPTION
## Summary
- fix bash redirection in `.chezmoi.toml.tmpl`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: unexpected ">" in operand)*
- `yes "" | bin/chezmoi init --source=/workspace/dotfiles --no-tty --debug --apply`

------
https://chatgpt.com/codex/tasks/task_e_68858a1ba74c832f9d6db93514a4095d