### PR TITLE
Add swaylock dark theme

### DIFF
--- a/dot_config/swaylock/config
+++ b/dot_config/swaylock/config
@@ -1,0 +1,14 @@
+# Dark theme for swaylock
+# Set the general background color to near-black
+color=11111b
+
+# Indicator colors
+inside-color=282828
+ring-color=444444
+text-color=f0f0f0
+key-hl-color=89b4fa
+bs-hl-color=f38ba8
+
+# Show clock and indicator
+clock
+indicator


### PR DESCRIPTION
## Summary
- set a dark color scheme for swaylock

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68858d8aed7c832f8ed6503a91f5ce9c