### PR TITLE
Add kdeconnect autostart for Hyprland

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -191,6 +191,7 @@ exec-once = dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CUR
 exec-once = {{$clipse}} -listen
 exec-once = solaar -w hide
 exec-once = kded5
+exec-once = kdeconnect-indicator
 exec-once = [workspace m silent] flatpak run com.spotify.Client
 exec-once = flatpak run com.spotify.Client
 windowrulev2 = workspace m, class:^(Spotify|spotify|org.spotify.Client)$


### PR DESCRIPTION
## Summary
- run `kdeconnect-indicator` on Hyprland startup

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68859279f43c832f83c7fb7c69cbe001