### PR TITLE
Add backward window cycling keybind

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -144,6 +144,7 @@ bind = SUPER SHIFT, 7, movetoworkspace, 7
 bind = SUPER SHIFT, 8, movetoworkspace, 8
 bind = SUPER SHIFT, 9, movetoworkspace, 9
 bind = ALT,Tab,cyclenext,
+bind = SUPER SHIFT, Tab, cyclenext, prev
 bind = ALT,Tab,bringactivetotop,
 
 # Screen shots


### PR DESCRIPTION
## Summary
- configure Hyprland to allow Command+Shift+Tab for cycling windows backwards

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885e698adbc832fa018fe3ad9735a78