### PR TITLE
Add Hyprshot installer and configure bindings

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -221,6 +221,27 @@
   {{- $xinputLocation = lookPath "xinput" -}}
 {{- end -}}
 
+{{- $grimLocation := findExecutable "grim" $paths -}}
+{{- if eq $grimLocation "" -}}
+  {{- $grimLocation = lookPath "grim" -}}
+{{- end -}}
+{{- $slurpLocation := findExecutable "slurp" $paths -}}
+{{- if eq $slurpLocation "" -}}
+  {{- $slurpLocation = lookPath "slurp" -}}
+{{- end -}}
+{{- $wlCopyLocation := findExecutable "wl-copy" $paths -}}
+{{- if eq $wlCopyLocation "" -}}
+  {{- $wlCopyLocation = lookPath "wl-copy" -}}
+{{- end -}}
+{{- $hyprpickerLocation := findExecutable "hyprpicker" $paths -}}
+{{- if eq $hyprpickerLocation "" -}}
+  {{- $hyprpickerLocation = lookPath "hyprpicker" -}}
+{{- end -}}
+{{- $hyprshotLocation := findExecutable "hyprshot" $paths -}}
+{{- if eq $hyprshotLocation "" -}}
+  {{- $hyprshotLocation = lookPath "hyprshot" -}}
+{{- end -}}
+
 {{- $wofiLocation := findExecutable "wofi" $paths -}}
 {{- if eq $wofiLocation "" -}}
   {{- $wofiLocation = lookPath "wofi" -}}
@@ -416,6 +437,24 @@
         {{- writeToStdout "Can't find xinput \n" -}}
 {{- end -}}
 
+{{- if not (stat $grimLocation ) -}}
+        {{- writeToStdout "Can't find grim \n" -}}
+{{- end -}}
+{{- if not (stat $slurpLocation ) -}}
+        {{- writeToStdout "Can't find slurp \n" -}}
+{{- end -}}
+{{- if not (stat $wlCopyLocation ) -}}
+        {{- writeToStdout "Can't find wl-copy \n" -}}
+{{- end -}}
+{{- if not (stat $hyprpickerLocation ) -}}
+        {{- writeToStdout "Can't find hyprpicker \n" -}}
+{{- end -}}
+{{- if not (stat $hyprshotLocation ) -}}
+        {{- writeToStdout "Can't find hyprshot (run installtool hyprshot) \n" -}}
+{{- else -}}
+        {{- writeToStdout (printf "hyprshot installed at %s\n" $hyprshotLocation) -}}
+{{- end -}}
+
 [git]
     autoCommit = {{ $autoGit }}
     autoPush = {{ $autoGit }}
@@ -461,6 +500,11 @@
         digLocation="{{$digLocation}}"
         jqLocation="{{$jqLocation}}"
         xinputLocation="{{$xinputLocation}}"
+        grimLocation="{{$grimLocation}}"
+        slurpLocation="{{$slurpLocation}}"
+        wlCopyLocation="{{$wlCopyLocation}}"
+        hyprpickerLocation="{{$hyprpickerLocation}}"
+        hyprshotLocation="{{$hyprshotLocation}}"
         chromeLocation="{{$chromeLocation}}"
         wofiLocation="{{$wofiLocation}}"
         rofiLocation="{{$rofiLocation}}"

--- a/bin/installtool
+++ b/bin/installtool
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
       shift
       version="${1:-latest}"
       ;;
-    list|git-credential-oauth|git-tag-inc|flutter|gh|clipse)
+  list|git-credential-oauth|git-tag-inc|flutter|gh|clipse|hyprshot)
       command="$1"
       ;;
   esac
@@ -77,6 +77,14 @@ install_clipse() {
   go install github.com/arran4/clipse@"$version"
 }
 
+install_hyprshot() {
+  url="https://raw.githubusercontent.com/Gustash/Hyprshot/refs/heads/main/hyprshot"
+  dest="$HOME/.local/bin/hyprshot"
+  mkdir -p "$(dirname "$dest")"
+  curl -fsSL "$url" -o "$dest"
+  chmod +x "$dest"
+}
+
 is_installed() {
   case "$1" in
     git-credential-oauth)
@@ -94,11 +102,14 @@ is_installed() {
     clipse)
       command -v clipse >/dev/null 2>&1
       ;;
+    hyprshot)
+      command -v hyprshot >/dev/null 2>&1
+      ;;
   esac
 }
 
 cmd_list() {
-  for tool in git-credential-oauth git-tag-inc gh flutter clipse; do
+  for tool in git-credential-oauth git-tag-inc gh flutter clipse hyprshot; do
     if is_installed "$tool"; then
       echo "* $tool"
     else
@@ -125,6 +136,9 @@ case "$command" in
     ;;
   clipse)
     install_clipse
+    ;;
+  hyprshot)
+    install_hyprshot
     ;;
   *)
     usage

--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -158,6 +158,19 @@ bind = ALT,Tab,bringactivetotop,
 #WindowUnderCursorScreenShot=Meta+Ctrl+Print
 
 #bind = META, PRINT, exec, spectacle -a -c
+{{- if and (ne .grimLocation "") (ne .slurpLocation "") (ne .wlCopyLocation "") (ne .hyprpickerLocation "") -}}
+  {{- if ne .hyprshotLocation "" -}}
+bind = SUPER, PRINT, exec, hyprshot -m window
+bind = SHIFT, PRINT, exec, hyprshot -m screen
+bind = SUPER SHIFT, PRINT, exec, hyprshot -m region
+bind = SUPER CTRL, PRINT, exec, hyprshot -m window
+  {{- else -}}
+bind = SUPER, PRINT, exec, grim -g "$(slurp -w)" - | wl-copy
+bind = SHIFT, PRINT, exec, grim - | wl-copy
+bind = SUPER SHIFT, PRINT, exec, grim -g "$(slurp)" - | wl-copy
+bind = SUPER CTRL, PRINT, exec, grim -g "$(slurp -w)" - | wl-copy
+  {{- end -}}
+{{- end -}}
 
 # Lock
 #bind = SUPER, L, exec, swaylock


### PR DESCRIPTION
## Summary
- add installer for hyprshot to `installtool`
- configure Hyprland screenshot keybindings using hyprshot
- record hyprshot and dependency locations in `.chezmoi.toml.tmpl`
- enable bindings only when hyprshot and all dependencies are present
- fall back to grim, slurp and wl-copy if hyprshot isn't installed

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885ab3d2bac832f9999646672424f14