### PR TITLE
Improve Anytype detection

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -51,6 +51,7 @@
         {{- $paths = append $paths "/var/lib/flatpak/exports/bin" -}}
         {{- $paths = append $paths "/usr/games/bin" -}}
         {{- $paths = append $paths "/opt/Bitwarden" -}}
+        {{- $paths = append $paths "/opt/bin" -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "rxvt" "xterm" "linux" "vt100" -}}
 #{{ else if eq .chezmoi.os "windows" }} Windows
@@ -242,6 +243,10 @@
   {{- $hyprshotLocation = lookPath "hyprshot" -}}
 {{- end -}}
 
+{{- $anytypeLocation := findExecutable "Anytype.AppImage" $paths -}}
+{{- if eq $anytypeLocation "" -}}
+  {{- $anytypeLocation = lookPath "Anytype.AppImage" -}}
+{{- end -}}
 {{- $wofiLocation := findExecutable "wofi" $paths -}}
 {{- if eq $wofiLocation "" -}}
   {{- $wofiLocation = lookPath "wofi" -}}
@@ -455,6 +460,11 @@
         {{- writeToStdout (printf "hyprshot installed at %s\n" $hyprshotLocation) -}}
 {{- end -}}
 
+{{- if not (stat $anytypeLocation ) -}}
+        {{- writeToStdout "Can't find Anytype.AppImage \n" -}}
+{{- else -}}
+        {{- writeToStdout (printf "Anytype installed at %s\n" $anytypeLocation) -}}
+{{- end -}}
 [git]
     autoCommit = {{ $autoGit }}
     autoPush = {{ $autoGit }}
@@ -506,6 +516,7 @@
         hyprpickerLocation="{{$hyprpickerLocation}}"
         hyprshotLocation="{{$hyprshotLocation}}"
         chromeLocation="{{$chromeLocation}}"
+        anytypeLocation="{{$anytypeLocation}}"
         wofiLocation="{{$wofiLocation}}"
         rofiLocation="{{$rofiLocation}}"
         dmenuRunLocation="{{$dmenuRunLocation}}"

--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -42,6 +42,7 @@
 {{- else if ne .xtermLocation "" -}}
   {{- $popupTerm = .xtermLocation -}}
 {{- end -}}
+{{- $anytype := .anytypeLocation -}}
 
 # ------------------------
 # Monitors (customize names + positions)
@@ -261,5 +262,7 @@ exec-once = kdeconnect-indicator
 exec-once = [workspace special:music silent] flatpak run com.spotify.Client
 windowrulev2 = workspace special:music, class:^(Spotify|spotify|org.spotify.Client)$
 exec-once = [workspace special:terminal silent] {{$terminal}}
-exec-once = [workspace special:anytype silent] /opt/bin/Anytype.AppImage
+{{- if ne $anytype "" -}}
+exec-once = [workspace special:anytype silent] {{$anytype}}
+{{- end -}}
 windowrulev2 = workspace special:anytype, class:^(Anytype)$


### PR DESCRIPTION
## Summary
- add Anytype path discovery and include `/opt/bin` in search paths
- autostart Anytype only when detected in Hyprland

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885ed84722c832f91343fd4f61ddb91