### PR TITLE
Add pager and host display to waybar

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -4,8 +4,8 @@
   "height": 30,
   "spacing": 1,
   "margin": 0,
-  "modules-left": ["sway/workspaces", "sway/mode", "custom/weather", "custom/quote"],
-    "modules-center": [],                                                                           //battery   //disk     // uptime      //updates        // systray
+  "modules-left": ["sway/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
+    "modules-center": ["custom/userhost"],                                                                           //battery   //disk     // uptime      //updates        // systray
   "modules-right": ["clock","pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
 
@@ -60,6 +60,18 @@
     "exec": "fortune -s",
     "on-click": "fortune | yad --text-info --width=400 --height=200 --title='Fortune'",
     "tooltip": true
+  },
+
+  "custom/pager": {
+    "exec": "$HOME/.config/waybar/scripts/pager.sh",
+    "interval": 1,
+    "on-click": "swaymsg workspace next",
+    "on-click-right": "swaymsg workspace prev"
+  },
+
+  "custom/userhost": {
+    "exec": "$HOME/.config/waybar/scripts/userhost.sh",
+    "interval": 600
   },
 
   "custom/updates": {

--- a/dot_config/waybar/scripts/pager.sh
+++ b/dot_config/waybar/scripts/pager.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Show current workspace index and total number of workspaces
+workspaces=$(swaymsg -t get_workspaces)
+current=$(echo "$workspaces" | jq '.[] | select(.focused).num')
+total=$(echo "$workspaces" | jq length)
+printf "%d/%d" "$current" "$total"
+

--- a/dot_config/waybar/scripts/userhost.sh
+++ b/dot_config/waybar/scripts/userhost.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+printf "%s@%s" "$(whoami)" "$(hostname)"
+

--- a/dot_config/waybar/style.css
+++ b/dot_config/waybar/style.css
@@ -116,7 +116,7 @@ window#waybar {
 #mode, #mpd, #custom-weather, #custom-playerctl, #clock, #cpu,
 #memory, #temperature, #battery, #network, #pulseaudio,
 #backlight, #disk, #custom-uptime, #custom-updates, #custom-quote,
-#idle_inhibitor, #tray {
+#custom-pager, #custom-userhost, #idle_inhibitor, #tray {
     padding: 0 10px;
     margin: 0 2px;
     border-bottom: 2px solid transparent;
@@ -272,6 +272,17 @@ window#waybar {
 #custom-quote {
     color: @quote-color;
     border-bottom-color: @quote-color;
+}
+
+#custom-pager {
+    color: @foreground;
+    border-bottom-color: @foreground;
+}
+
+#custom-userhost {
+    font-weight: bold;
+    color: @foreground;
+    border-bottom-color: transparent;
 }
 
 #idle_inhibitor {


### PR DESCRIPTION
## Summary
- show `user@host` in center of waybar
- add pager module with click actions
- style new modules

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885fe523224832f850d4a28e185c349