### PR TITLE
Add conditional Waybar hyprland support

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -242,6 +242,10 @@
 {{- if eq $hyprshotLocation "" -}}
   {{- $hyprshotLocation = lookPath "hyprshot" -}}
 {{- end -}}
+{{- $hyprctlLocation := findExecutable "hyprctl" $paths -}}
+{{- if eq $hyprctlLocation "" -}}
+  {{- $hyprctlLocation = lookPath "hyprctl" -}}
+{{- end -}}
 
 {{- $anytypeLocation := findExecutable "Anytype.AppImage" $paths -}}
 {{- if eq $anytypeLocation "" -}}
@@ -459,6 +463,9 @@
 {{- else -}}
         {{- writeToStdout (printf "hyprshot installed at %s\n" $hyprshotLocation) -}}
 {{- end -}}
+{{- if not (stat $hyprctlLocation ) -}}
+        {{- writeToStdout "Can't find hyprctl \n" -}}
+{{- end -}}
 
 {{- if not (stat $anytypeLocation ) -}}
         {{- writeToStdout "Can't find Anytype.AppImage \n" -}}
@@ -515,6 +522,7 @@
         wlCopyLocation="{{$wlCopyLocation}}"
         hyprpickerLocation="{{$hyprpickerLocation}}"
         hyprshotLocation="{{$hyprshotLocation}}"
+        hyprctlLocation="{{$hyprctlLocation}}"
         chromeLocation="{{$chromeLocation}}"
         anytypeLocation="{{$anytypeLocation}}"
         wofiLocation="{{$wofiLocation}}"

--- a/dot_config/waybar/config.jsonc.tmpl
+++ b/dot_config/waybar/config.jsonc.tmpl
@@ -4,7 +4,11 @@
   "height": 30,
   "spacing": 1,
   "margin": 0,
+  {{- if (stat .hyprctlLocation) -}}
+  "modules-left": ["hyprland/workspaces", "hyprland/mode", "hyprland/scratchpad", "custom/media"],
+{{- else -}}
   "modules-left": ["sway/workspaces", "sway/mode", "custom/weather", "custom/quote"],
+{{- end -}}
     "modules-center": [],                                                                           //battery   //disk     // uptime      //updates        // systray
   "modules-right": ["clock","pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
@@ -45,6 +49,15 @@
     "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{markup_escape(title)}}\", \"tooltip\": \"{{playerName}} : {{artist}} - {{markup_escape(title)}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' -F",
     "on-click": "playerctl play-pause",
     "on-click-right": "playerctl next",
+  },
+
+  "custom/media": {
+    "format": " 󰐊 {}",
+    "return-type": "json",
+    "max-length": 40,
+    "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{markup_escape(title)}}\", \"tooltip\": \"{{playerName}} : {{artist}} - {{markup_escape(title)}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' -F",
+    "on-click": "playerctl play-pause",
+    "on-click-right": "playerctl next"
   },
 
   "custom/weather": {

--- a/dot_config/waybar/style.css
+++ b/dot_config/waybar/style.css
@@ -75,6 +75,7 @@
 @define-color mpd-color @magenta;
 @define-color weather-color @magenta;
 @define-color playerctl-color @magenta;
+@define-color media-color @magenta;
 @define-color clock-color @blue;
 @define-color cpu-color @green;
 @define-color memory-color @magenta;
@@ -113,7 +114,7 @@ window#waybar {
 
 
 /* Common module styling with border-bottom */
-#mode, #mpd, #custom-weather, #custom-playerctl, #clock, #cpu,
+#mode, #mpd, #custom-weather, #custom-playerctl, #custom-media, #clock, #cpu,
 #memory, #temperature, #battery, #network, #pulseaudio,
 #backlight, #disk, #custom-uptime, #custom-updates, #custom-quote,
 #idle_inhibitor, #tray {
@@ -170,9 +171,15 @@ window#waybar {
 }
 
 #custom-playerctl {
+
     color: @playerctl-color;
     border-bottom-color: @playerctl-color;
 }
+#custom-media {
+    color: @media-color;
+    border-bottom-color: @media-color;
+}
+
 
 #custom-playerctl.Playing {
     color: @cyan;


### PR DESCRIPTION
## Summary
- add hyprctl detection to `.chezmoi.toml.tmpl`
- template Waybar to use hyprland modules when hyprctl is present
- style Waybar custom media module

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885fec21a44832fada10843dcedf913