### PR TITLE
Add spotify module to Waybar config

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -6,7 +6,7 @@
   "margin": 0,
   "modules-left": ["sway/workspaces", "sway/mode", "custom/weather", "custom/quote"],
     "modules-center": [],                                                                           //battery   //disk     // uptime      //updates        // systray
-  "modules-right": ["clock","pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
+  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
 
   "sway/workspaces": {
@@ -45,6 +45,15 @@
     "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{markup_escape(title)}}\", \"tooltip\": \"{{playerName}} : {{artist}} - {{markup_escape(title)}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' -F",
     "on-click": "playerctl play-pause",
     "on-click-right": "playerctl next",
+  },
+
+  "custom/spotify": {
+    "format": " {}",
+    "return-type": "json",
+    "max-length": 40,
+    "exec": "playerctl -p spotify metadata --format '{\"text\": \"{{artist}} - {{markup_escape(title)}}\", \"tooltip\": \"Spotify: {{artist}} - {{markup_escape(title)}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' -F",
+    "on-click": "playerctl play-pause",
+    "on-click-right": "playerctl next"
   },
 
   "custom/weather": {

--- a/dot_config/waybar/style.css
+++ b/dot_config/waybar/style.css
@@ -75,6 +75,7 @@
 @define-color mpd-color @magenta;
 @define-color weather-color @magenta;
 @define-color playerctl-color @magenta;
+@define-color spotify-color @magenta;
 @define-color clock-color @blue;
 @define-color cpu-color @green;
 @define-color memory-color @magenta;
@@ -113,7 +114,7 @@ window#waybar {
 
 
 /* Common module styling with border-bottom */
-#mode, #mpd, #custom-weather, #custom-playerctl, #clock, #cpu,
+#mode, #mpd, #custom-weather, #custom-playerctl, #custom-spotify, #clock, #cpu,
 #memory, #temperature, #battery, #network, #pulseaudio,
 #backlight, #disk, #custom-uptime, #custom-updates, #custom-quote,
 #idle_inhibitor, #tray {
@@ -174,12 +175,28 @@ window#waybar {
     border-bottom-color: @playerctl-color;
 }
 
+
 #custom-playerctl.Playing {
     color: @cyan;
     border-bottom-color: @cyan;
 }
 
 #custom-playerctl.Paused {
+    color: @orange;
+    border-bottom-color: @orange;
+}
+
+#custom-spotify {
+    color: @spotify-color;
+    border-bottom-color: @spotify-color;
+}
+
+#custom-spotify.Playing {
+    color: @cyan;
+    border-bottom-color: @cyan;
+}
+
+#custom-spotify.Paused {
     color: @orange;
     border-bottom-color: @orange;
 }


### PR DESCRIPTION
## Summary
- show Spotify info in the Waybar panel
- style the new module in Waybar CSS

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885fee457e0832f9df6d456872ffe7a