### PR TITLE
Fix 24h time in waybar clock

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -87,8 +87,8 @@
 
   "clock": {
     "format": "󰥔 {:%H:%M}",
-    "format-alt": "󰃮 {:%Y-%m-%d}",
-    "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>",
+    "format-alt": "󰃮 {:%Y-%m-%d %H:%M}",
+    "tooltip-format": "<big>{:%Y %B %H:%M}</big>\n<tt><small>{calendar}</small></tt>",
     "calendar": {
       "mode"          : "month",
       "mode-mon-col"  : 3,


### PR DESCRIPTION
## Summary
- ensure Waybar always shows 24h time by updating clock module

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_688617b0ab18832f974363e263731f9a