### PR TITLE
Enable special Hyprland workspaces in Waybar

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -4,7 +4,7 @@
   "height": 30,
   "spacing": 1,
   "margin": 0,
-  "modules-left": ["sway/workspaces", "sway/mode", "custom/weather", "custom/quote"],
+  "modules-left": ["sway/workspaces", "hyprland/workspaces", "sway/mode", "custom/weather", "custom/quote"],
     "modules-center": [],                                                                           //battery   //disk     // uptime      //updates        // systray
   "modules-right": ["clock","pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
@@ -24,6 +24,33 @@
       "8": "󰣇",
       "9": "",
       "10": ""
+    },
+    "persistent_workspaces": {
+      "1": [],
+      "2": [],
+      "3": [],
+      "4": [],
+      "5": []
+    }
+  },
+  "hyprland/workspaces": {
+    "all-outputs": true,
+    "format": "{name}",
+    "show-special": true,
+    "format-icons": {
+      "1": "󰖟",
+      "2": "",
+      "3": "",
+      "4": "󰭹",
+      "5": "󰕧",
+      "6": "",
+      "7": "",
+      "8": "󰣇",
+      "9": "",
+      "10": "",
+      "special:music": "󰝚",
+      "special:terminal": "",
+      "special:anytype": "󰛧"
     },
     "persistent_workspaces": {
       "1": [],

--- a/dot_config/waybar/style.css
+++ b/dot_config/waybar/style.css
@@ -69,6 +69,7 @@
 @define-color workspaces-focused-fg @cyan;
 @define-color workspaces-urgent-bg @red;
 @define-color workspaces-urgent-fg @black;
+@define-color workspaces-special-fg @magenta;
 
 /* Text and border colors for modules */
 @define-color mode-color @orange;
@@ -145,6 +146,10 @@ window#waybar {
 #workspaces button.urgent {
     background-color: @workspaces-urgent-bg;
     color: @workspaces-urgent-fg;
+}
+
+#workspaces button.special {
+    color: @workspaces-special-fg;
 }
 
 /* Module-specific styling */


### PR DESCRIPTION
## Summary
- display Hyprland special workspaces in Waybar
- highlight special workspaces in style sheet

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6885fd2bb1c8832faab3163eb4ba77f3