### PR TITLE
Add Waybar audio sink switcher

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -170,6 +170,7 @@
       "default": ["󰕿", "󰖀", "󰕾"]
     },
     "on-click": "pavucontrol",
+    "on-click-middle": "~/.config/waybar/switch-audio-sink.sh",
     "on-click-right": "pactl set-sink-mute @DEFAULT_SINK@ toggle",
     "on-scroll-up": "pactl set-sink-volume @DEFAULT_SINK@ +2%",
     "on-scroll-down": "pactl set-sink-volume @DEFAULT_SINK@ -2%"

--- a/dot_config/waybar/executable_switch-audio-sink.sh.tmpl
+++ b/dot_config/waybar/executable_switch-audio-sink.sh.tmpl
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+menu_cmd={{- if ne .wofiLocation "" -}}"{{.wofiLocation}} --show dmenu --prompt 'Sink'"{{- else if ne .rofiLocation "" -}}"{{.rofiLocation}} -dmenu -p 'Sink'"{{- else -}}"dmenu -p 'Sink'"{{- end }}
+
+sinks=$(pactl -f json list sinks | jq -r '.sinks[] | "\(.index)\t\(.description)"')
+choice=$(echo "$sinks" | eval "$menu_cmd")
+[ -z "$choice" ] && exit 0
+
+sink_index=$(echo "$choice" | cut -f1)
+
+pactl set-default-sink "$sink_index"
+pactl list short sink-inputs | awk '{print $1}' | while read -r input; do
+  pactl move-sink-input "$input" "$sink_index"
+done
+


### PR DESCRIPTION
## Summary
- add `switch-audio-sink.sh` Waybar helper under dot_config
- call this script from the volume block via middle click

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_688617ca5d9c832f808606dda893b38b