### PR TITLE
Remove wezterm terminal fallback

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -264,10 +264,6 @@
 {{- if eq $terminatorLocation "" -}}
   {{- $terminatorLocation = lookPath "terminator" -}}
 {{- end -}}
-{{- $weztermLocation := findExecutable "wezterm" $paths -}}
-{{- if eq $weztermLocation "" -}}
-  {{- $weztermLocation = lookPath "wezterm" -}}
-{{- end -}}
 {{- $konsoleLocation := findExecutable "konsole" $paths -}}
 {{- if eq $konsoleLocation "" -}}
   {{- $konsoleLocation = lookPath "konsole" -}}
@@ -285,8 +281,8 @@
   {{- $xtermLocation = lookPath "xterm" -}}
 {{- end -}}
 
-{{- if and (eq .chezmoi.os "linux") (eq $terminatorLocation "") (eq $weztermLocation "") (eq $konsoleLocation "") (eq $alacrittyLocation "") (eq $urxvtLocation "") (eq $xtermLocation "") -}}
-        {{- writeToStdout "Can't find terminal (terminator/wezterm/konsole/alacritty/urxvt/xterm) \n" -}}
+{{- if and (eq .chezmoi.os "linux") (eq $terminatorLocation "") (eq $konsoleLocation "") (eq $alacrittyLocation "") (eq $urxvtLocation "") (eq $xtermLocation "") -}}
+        {{- writeToStdout "Can't find terminal (terminator/konsole/alacritty/urxvt/xterm) \n" -}}
 {{- end -}}
 
 {{- if and (eq .chezmoi.os "linux") (eq $wofiLocation "") (eq $rofiLocation "") (eq $dmenuRunLocation "") -}}
@@ -521,7 +517,6 @@
         rofiLocation="{{$rofiLocation}}"
         dmenuRunLocation="{{$dmenuRunLocation}}"
         terminatorLocation="{{$terminatorLocation}}"
-        weztermLocation="{{$weztermLocation}}"
         konsoleLocation="{{$konsoleLocation}}"
         alacrittyLocation="{{$alacrittyLocation}}"
         urxvtLocation="{{$urxvtLocation}}"

--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -22,8 +22,6 @@
 {{- $terminal := "" -}}
 {{- if ne .terminatorLocation "" -}}
   {{- $terminal = .terminatorLocation -}}
-{{- else if ne .weztermLocation "" -}}
-  {{- $terminal = .weztermLocation -}}
 {{- else if ne .konsoleLocation "" -}}
   {{- $terminal = .konsoleLocation -}}
 {{- else if ne .alacrittyLocation "" -}}


### PR DESCRIPTION
## Summary
- drop wezterm from terminal discovery and hyprland preferences

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68861ff00d0c832fa7b59fcbd6de32c6