### PR TITLE
Fix Waybar pager script permissions

### DIFF
--- a/dot_config/waybar/scripts/executable_pager.sh
+++ b/dot_config/waybar/scripts/executable_pager.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Show current workspace index and total number of workspaces
+ws=$(swaymsg -t get_workspaces)
+current=$(echo "$ws" | jq -r '.[] | select(.focused).num')
+total=$(echo "$ws" | jq -r length)
+printf "%d/%d" "$current" "$total"
+

--- a/dot_config/waybar/scripts/pager.sh
+++ b/dot_config/waybar/scripts/pager.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-# Show current workspace index and total number of workspaces
-workspaces=$(swaymsg -t get_workspaces)
-current=$(echo "$workspaces" | jq '.[] | select(.focused).num')
-total=$(echo "$workspaces" | jq length)
-printf "%d/%d" "$current" "$total"
-


### PR DESCRIPTION
## Summary
- ensure pager.sh is applied as executable by renaming it with Chezmoi's `executable_` prefix
- streamline pager.sh variable names and add `-r` to jq for readability

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_68861ec0ca9c832fa2a32ed18cfc1689