### PR TITLE
Handle missing swaymsg for waybar

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -243,6 +243,11 @@
   {{- $hyprshotLocation = lookPath "hyprshot" -}}
 {{- end -}}
 
+{{- $swaymsgLocation := findExecutable "swaymsg" $paths -}}
+{{- if eq $swaymsgLocation "" -}}
+  {{- $swaymsgLocation = lookPath "swaymsg" -}}
+{{- end -}}
+
 {{- $anytypeLocation := findExecutable "Anytype.AppImage" $paths -}}
 {{- if eq $anytypeLocation "" -}}
   {{- $anytypeLocation = lookPath "Anytype.AppImage" -}}
@@ -455,6 +460,9 @@
 {{- else -}}
         {{- writeToStdout (printf "hyprshot installed at %s\n" $hyprshotLocation) -}}
 {{- end -}}
+{{- if not (stat $swaymsgLocation ) -}}
+        {{- writeToStdout "Can't find swaymsg \n" -}}
+{{- end -}}
 
 {{- if not (stat $anytypeLocation ) -}}
         {{- writeToStdout "Can't find Anytype.AppImage \n" -}}
@@ -511,6 +519,7 @@
         wlCopyLocation="{{$wlCopyLocation}}"
         hyprpickerLocation="{{$hyprpickerLocation}}"
         hyprshotLocation="{{$hyprshotLocation}}"
+        swaymsgLocation="{{$swaymsgLocation}}"
         chromeLocation="{{$chromeLocation}}"
         anytypeLocation="{{$anytypeLocation}}"
         wofiLocation="{{$wofiLocation}}"

--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -106,8 +106,8 @@
   "custom/pager": {
     "exec": "$HOME/.config/waybar/scripts/pager.sh",
     "interval": 1,
-    "on-click": "swaymsg workspace next",
-    "on-click-right": "swaymsg workspace prev"
+    "on-click": "$HOME/.config/waybar/scripts/workspace_switch.sh next",
+    "on-click-right": "$HOME/.config/waybar/scripts/workspace_switch.sh prev"
   },
 
   "custom/userhost": {

--- a/dot_config/waybar/scripts/executable_pager.sh
+++ b/dot_config/waybar/scripts/executable_pager.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 # Show current workspace index and total number of workspaces
-ws=$(swaymsg -t get_workspaces)
-current=$(echo "$ws" | jq -r '.[] | select(.focused).num')
-total=$(echo "$ws" | jq -r length)
+if command -v swaymsg >/dev/null 2>&1; then
+  ws=$(swaymsg -t get_workspaces)
+  current=$(echo "$ws" | jq -r '.[] | select(.focused).num')
+  total=$(echo "$ws" | jq -r length)
+elif command -v hyprctl >/dev/null 2>&1; then
+  ws=$(hyprctl -j workspaces)
+  current=$(echo "$ws" | jq -r '.[] | select(.focused or .active).id')
+  total=$(echo "$ws" | jq -r length)
+else
+  exit 0
+fi
 printf "%d/%d" "$current" "$total"
 

--- a/dot_config/waybar/scripts/executable_workspace_switch.sh
+++ b/dot_config/waybar/scripts/executable_workspace_switch.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Switch workspaces for Waybar
+# Usage: workspace_switch.sh next|prev
+cmd="$1"
+if command -v swaymsg >/dev/null 2>&1; then
+  if [ "$cmd" = "prev" ]; then
+    swaymsg workspace prev
+  else
+    swaymsg workspace next
+  fi
+elif command -v hyprctl >/dev/null 2>&1; then
+  if [ "$cmd" = "prev" ]; then
+    hyprctl dispatch workspace e-1
+  else
+    hyprctl dispatch workspace e+1
+  fi
+fi
+


### PR DESCRIPTION
## Summary
- handle fallback to hyprctl in the pager script
- add a new workspace_switch script for waybar
- use workspace_switch in waybar config
- record swaymsg path discovery in chezmoi config

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68862c044194832f92cb70f813e68277