### PR TITLE
Add maximum scrollback for Alacritty

### DIFF
--- a/dot_config/alacritty/alacritty.toml
+++ b/dot_config/alacritty/alacritty.toml
@@ -2,3 +2,6 @@
 [window]
 opacity = 0.9
 
+[scrolling]
+history = 100000
+


### PR DESCRIPTION
## Summary
- set `scrolling.history` to the maximum value allowed by Alacritty

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68862c67dad0832fbfb2b7548af23b79