### PR TITLE
Add blur option to alacritty

### DIFF
--- a/dot_config/alacritty/alacritty.toml
+++ b/dot_config/alacritty/alacritty.toml
@@ -1,4 +1,4 @@
 # Alacritty configuration
 [window]
 opacity = 0.9
-
+blur = true


### PR DESCRIPTION
## Summary
- enable macOS blur effect for Alacritty

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_68862d131e0c832f8badaddb016f861e