### PR TITLE
Remove package update widget from waybar

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -7,7 +7,7 @@
 
   "modules-left": ["sway/workspaces", "hyprland/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
   "modules-center": ["custom/userhost", "hyprland/window"],
-  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
+  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "tray"],
 
     
   "sway/workspaces": {
@@ -115,13 +115,6 @@
     "interval": 600
   },
 
-  "custom/updates": {
-    "format": "󰚰 {}",
-    "exec": "checkupdates | wc -l",
-    "interval": 3600,
-    "on-click": "kitty -e sudo pacman -Syu",
-    "signal": 8
-  },
 
   "custom/uptime": {
     "format": "󰔟 {}",

--- a/dot_config/waybar/style.css
+++ b/dot_config/waybar/style.css
@@ -109,7 +109,6 @@
 @define-color backlight-color @yellow;
 @define-color disk-color @cyan;
 @define-color uptime-color @green;
-@define-color updates-color @orange;
 @define-color quote-color @green;
 @define-color idle-inhibitor-color @foreground;
 @define-color idle-inhibitor-active-color @red;
@@ -133,7 +132,7 @@ window#waybar {
 /* Common module styling with border-bottom */
 #mode, #mpd, #custom-weather, #custom-playerctl, #custom-spotify, #clock, #cpu,
 #memory, #temperature, #battery, #network, #pulseaudio,
-#backlight, #disk, #custom-uptime, #custom-updates, #custom-quote,
+#backlight, #disk, #custom-uptime, #custom-quote,
 #custom-pager, #custom-userhost, #idle_inhibitor, #tray {
     padding: 0 10px;
     margin: 0 2px;
@@ -302,10 +301,6 @@ window#waybar {
     border-bottom-color: @uptime-color;
 }
 
-#custom-updates {
-    color: @updates-color;
-    border-bottom-color: @updates-color;
-}
 
 #custom-quote {
     color: @quote-color;


### PR DESCRIPTION
## Summary
- remove `custom/updates` module from waybar configuration
- drop update related styles

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_688633497274832fac80b50b1da5b602