### PR TITLE
Add GPU module to waybar

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -7,9 +7,9 @@
 
   "modules-left": ["sway/workspaces", "hyprland/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
   "modules-center": ["custom/userhost", "hyprland/window"],
-  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
+  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "custom/gpu", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
-    
+
   "sway/workspaces": {
     "disable-scroll": true,
     "all-outputs": true,
@@ -176,6 +176,12 @@
     "format": "󰍛 {}%",
     "interval": 1,
     "on-click": "kitty -e htop"
+  },
+
+  "custom/gpu": {
+    "format": "󰢮 {}",
+    "exec": "$HOME/.config/waybar/scripts/gpu.sh",
+    "interval": 5
   },
 
   "temperature": {

--- a/dot_config/waybar/scripts/executable_gpu.sh
+++ b/dot_config/waybar/scripts/executable_gpu.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv,noheader,nounits |
+  awk -F', *' '{printf "%s%% %s/%s MiB\n", $1, $2, $3}'


### PR DESCRIPTION
## Summary
- add a GPU monitoring script for waybar that uses `nvidia-smi`
- hook the script into waybar `config.jsonc`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b4b9f664832fbbb71c2fe8e1874a