### PR TITLE
Add custom hostname module

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -6,7 +6,7 @@
   "margin": 0,
 
   "modules-left": ["sway/workspaces", "hyprland/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
-  "modules-center": ["custom/userhost", "hyprland/window"],
+  "modules-center": ["custom/userhost", "custom/hostname", "hyprland/window"],
   "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
     
@@ -112,6 +112,11 @@
 
   "custom/userhost": {
     "exec": "$HOME/.config/waybar/scripts/userhost.sh",
+    "interval": 600
+  },
+
+  "custom/hostname": {
+    "exec": "hostname",
     "interval": 600
   },
 


### PR DESCRIPTION
## Summary
- show hostname in waybar by adding a new custom module

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b4c8d05c832f9aadcb7facdea09c