### PR TITLE
Add Waybar screenshot module

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -7,9 +7,9 @@
 
   "modules-left": ["sway/workspaces", "hyprland/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
   "modules-center": ["custom/userhost", "hyprland/window"],
-  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
+  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "custom/screenshot", "tray"],
 
-    
+
   "sway/workspaces": {
     "disable-scroll": true,
     "all-outputs": true,
@@ -121,6 +121,11 @@
     "interval": 3600,
     "on-click": "kitty -e sudo pacman -Syu",
     "signal": 8
+  },
+
+  "custom/screenshot": {
+    "format": "",
+    "on-click": "grim"
   },
 
   "custom/uptime": {


### PR DESCRIPTION
## Summary
- add `custom/screenshot` to the right side modules
- invoke `grim` on click

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b4e5cc5c832fa8809fb9a17900ee