### PR TITLE
Add custom net-total module for Waybar

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -7,7 +7,7 @@
 
   "modules-left": ["sway/workspaces", "hyprland/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
   "modules-center": ["custom/userhost", "hyprland/window"],
-  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
+  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "custom/net-total", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
 
     
   "sway/workspaces": {
@@ -206,6 +206,11 @@
     "format-alt": "{ifname}: {ipaddr}/{cidr}",
     "tooltip-format": "{ifname}: {ipaddr}",
     "on-click": "kitty -e nmtui"
+  },
+
+  "custom/net-total": {
+    "exec": "$HOME/.config/waybar/scripts/net-total.sh",
+    "interval": 5
   },
 
   "pulseaudio": {

--- a/dot_config/waybar/scripts/executable_net-total.sh
+++ b/dot_config/waybar/scripts/executable_net-total.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+awk '
+  NR > 2 {
+    rx += $2
+    tx += $10
+  }
+  END {
+    printf "RX: %.1f MB TX: %.1f MB\n", rx/1024/1024, tx/1024/1024
+  }
+' /proc/net/dev

--- a/dot_config/waybar/style.css
+++ b/dot_config/waybar/style.css
@@ -132,7 +132,7 @@ window#waybar {
 
 /* Common module styling with border-bottom */
 #mode, #mpd, #custom-weather, #custom-playerctl, #custom-spotify, #clock, #cpu,
-#memory, #temperature, #battery, #network, #pulseaudio,
+#memory, #temperature, #battery, #network, #custom-net-total, #pulseaudio,
 #backlight, #disk, #custom-uptime, #custom-updates, #custom-quote,
 #custom-pager, #custom-userhost, #idle_inhibitor, #tray {
     padding: 0 10px;
@@ -275,6 +275,11 @@ window#waybar {
 #network.disconnected {
     color: @network-disconnected-color;
     border-bottom-color: @network-disconnected-color;
+}
+
+#custom-net-total {
+  color: @network-color;
+  border-bottom-color: @network-color;
 }
 
 #pulseaudio {


### PR DESCRIPTION
## Summary
- display total network usage in Waybar
- call new script from `custom/net-total`
- style the new module in waybar CSS

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b5120110832fa0e2605bc3648f80