### PR TITLE
Add custom sysinfo tooltip for Waybar

### DIFF
--- a/dot_config/waybar/config.jsonc
+++ b/dot_config/waybar/config.jsonc
@@ -7,7 +7,7 @@
 
   "modules-left": ["sway/workspaces", "hyprland/workspaces", "custom/pager", "sway/mode", "custom/weather", "custom/quote"],
   "modules-center": ["custom/userhost", "hyprland/window"],
-  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/uptime", "custom/updates", "tray"],
+  "modules-right": ["clock", "custom/spotify", "pulseaudio", "backlight", "network", "cpu", "memory", "temperature", "battery", "disk", "custom/sysinfo", "custom/uptime", "custom/updates", "tray"],
 
     
   "sway/workspaces": {
@@ -127,6 +127,13 @@
     "format": "󰔟 {}",
     "exec": "uptime -p | sed 's/up //; s/ days/d/; s/ hours/h/; s/ minutes/m/'",
     "interval": 60
+  },
+
+  "custom/sysinfo": {
+    "format": "{}",
+    "return-type": "json",
+    "exec": "$HOME/.config/waybar/scripts/sysinfo.sh",
+    "interval": 30
   },
 
   "idle_inhibitor": {

--- a/dot_config/waybar/scripts/executable_sysinfo.sh
+++ b/dot_config/waybar/scripts/executable_sysinfo.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cpu=$(top -bn1 | grep "%Cpu" | awk '{print 100 - $8}')
+cpu=$(printf "%.1f" "$cpu")
+mem=$(free -m | awk '/^Mem:/ {printf "%.1f", $3/$2*100}')
+disk_info=$(df -h / | awk 'NR==2 {printf "%s (%s/%s)", $5, $3, $2}')
+printf '{"text":"\uf2db","tooltip":"CPU: %s%%\\nRAM: %s%%\\nDisk: %s"}\n' "$cpu" "$mem" "$disk_info"
+


### PR DESCRIPTION
## Summary
- add `custom/sysinfo` script for Waybar
- call the script from `config.jsonc` and enable the module

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`
- `dot_config/waybar/scripts/executable_sysinfo.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886b52ac768832f869d910d53692408