### PR TITLE
Add window rule for zenity and kdialog

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -264,3 +264,4 @@ windowrulev2 = workspace special:music, class:^(Spotify|spotify|org.spotify.Clie
 #exec-once = [workspace special:anytype silent] {{$anytype}}
 {{- end -}}
 windowrulev2 = workspace special:anytype, class:^(Anytype)$
+windowrulev2 = center, class:^(zenity|kdialog)$


### PR DESCRIPTION
## Summary
- center Zenity and KDialog popups with a windowrule

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b66837f8832f8c4324f3041d2eb7