### PR TITLE
Set Hyprland desktop environment

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -64,6 +64,7 @@ env = LIBVA_DRIVER_NAME,nvidia
 env = XDG_SESSION_TYPE,wayland
 env = GBM_BACKEND,nvidia-drm
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
+env = XDG_CURRENT_DESKTOP,hyprland
 
 cursor {
     no_hardware_cursors = true


### PR DESCRIPTION
## Summary
- set `env = XDG_CURRENT_DESKTOP,hyprland` in Hyprland configuration

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_6886b69f0074832f8e5c43f6cbe75404