### PR TITLE
Add wf-recorder keybind

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -242,6 +242,10 @@
 {{- if eq $hyprshotLocation "" -}}
   {{- $hyprshotLocation = lookPath "hyprshot" -}}
 {{- end -}}
+{{- $wfRecorderLocation := findExecutable "wf-recorder" $paths -}}
+{{- if eq $wfRecorderLocation "" -}}
+  {{- $wfRecorderLocation = lookPath "wf-recorder" -}}
+{{- end -}}
 
 {{- $anytypeLocation := findExecutable "Anytype.AppImage" $paths -}}
 {{- if eq $anytypeLocation "" -}}
@@ -455,6 +459,12 @@
 {{- else -}}
         {{- writeToStdout (printf "hyprshot installed at %s\n" $hyprshotLocation) -}}
 {{- end -}}
+{{- if not (stat $wfRecorderLocation ) -}}
+        {{- writeToStdout "Can't find wf-recorder \n" -}}
+{{- else -}}
+        {{- $wfRecorderVersion := trim (output $wfRecorderLocation "--version") -}}
+        {{- writeToStdout (printf "wf-recorder installed at %s (%s)\n" $wfRecorderLocation $wfRecorderVersion) -}}
+{{- end -}}
 
 {{- if not (stat $anytypeLocation ) -}}
         {{- writeToStdout "Can't find Anytype.AppImage \n" -}}
@@ -511,6 +521,7 @@
         wlCopyLocation="{{$wlCopyLocation}}"
         hyprpickerLocation="{{$hyprpickerLocation}}"
         hyprshotLocation="{{$hyprshotLocation}}"
+        wfRecorderLocation="{{$wfRecorderLocation}}"
         chromeLocation="{{$chromeLocation}}"
         anytypeLocation="{{$anytypeLocation}}"
         wofiLocation="{{$wofiLocation}}"

--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -189,6 +189,11 @@ bind = ALT,Tab,bringactivetotop,
 #RecordRegion=Meta+Shift+R
 #RecordScreen=Meta+Alt+R
 #RecordWindow=Meta+Ctrl+R
+{{- if and (ne .wfRecorderLocation "") (ne .slurpLocation "") -}}
+bind = SUPER_L SHIFT, R, exec, {{.wfRecorderLocation}} -g "$(slurp)"
+bind = SUPER_L ALT, R, exec, {{.wfRecorderLocation}}
+bind = SUPER_L CTRL, R, exec, {{.wfRecorderLocation}} -g "$(slurp -w)"
+{{- end -}}
 #RectangularRegionScreenShot=Meta+Shift+Print
 #WindowUnderCursorScreenShot=Meta+Ctrl+Print
 


### PR DESCRIPTION
## Summary
- check for wf-recorder in chezmoi template
- expose wfRecorderLocation data
- record region/screen/window only if wf-recorder and slurp are present

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_6886b6916a54832fad247157b9487813