### PR TITLE
Open floating terminal with Ctrl+Return

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -108,6 +108,8 @@ bind = CTRL SUPER_L, T, exec, {{$terminal}}
 #bind = CTRL SUPER_R, T, exec, {{$terminal}}
 # Terminal as alternate: Meta+Return
 bind = SUPER_L, RETURN, exec, {{$terminal}}
+# Floating terminal: Ctrl+Return
+bind = CTRL, RETURN, exec, [float] {{$terminal}}
 #bind = SUPER_R, RETURN, exec, {{$terminal}}
 bind = SUPER_L, SPACE, exec, {{$launcher}}
 #bind = SUPER_R, SPACE, exec, {{$launcher}}
@@ -228,6 +230,7 @@ bindm=ALT,mouse:273,resizewindow
 # ------------------------
 #windowrule = float, ^(pavucontrol|blueman-manager)$
 #windowrule = float, kitty
+# windowrulev2 = float, class:^(alacritty|kitty)$
 
 # ------------------------
 # Workspace rules


### PR DESCRIPTION
## Summary
- create a binding to launch a floating terminal with `Ctrl+Return`
- revert always floating terminal rule

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b57e306c832f8dc46c0a339f1d4e