### PR TITLE
Update hyprland media keys

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -42,6 +42,11 @@
 {{- end -}}
 {{- $anytype := .anytypeLocation -}}
 
+{{- $playerctlPlayer := "spotify" -}}
+{{- if ne .playerctlPlayer "" -}}
+  {{- $playerctlPlayer = .playerctlPlayer -}}
+{{- end -}}
+
 # ------------------------
 # Monitors (customize names + positions)
 # ------------------------
@@ -215,10 +220,10 @@ bind = SUPER_L, L, exec, {{$lockcmd}}
 binde=, XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.5 @DEFAULT_AUDIO_SINK@ 1%+
 bindl=, XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%-
 bindl=, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
-# Requires playerctl
-bindl=, XF86AudioPlay, exec, playerctl play-pause
-bindl=, XF86AudioPrev, exec, playerctl previous
-bindl=, XF86AudioNext, exec, playerctl next
+# Requires playerctl (set $playerctlPlayer to target a specific player)
+bindl=, XF86AudioPlay, exec, playerctl --player={{$playerctlPlayer}} play-pause
+bindl=, XF86AudioPrev, exec, playerctl --player={{$playerctlPlayer}} previous
+bindl=, XF86AudioNext, exec, playerctl --player={{$playerctlPlayer}} next
 ## Mouse bindings
 bindm=ALT,mouse:272,movewindow
 bindm=ALT,mouse:273,resizewindow


### PR DESCRIPTION
## Summary
- template Hyprland media player variable
- set default to `spotify`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886b56ab14c832fa768724702abc78f