### PR TITLE
Add conditional autostart programs

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -248,6 +248,23 @@
   {{- $swaymsgLocation = lookPath "swaymsg" -}}
 {{- end -}}
 
+{{- $solaarLocation := findExecutable "solaar" $paths -}}
+{{- if eq $solaarLocation "" -}}
+  {{- $solaarLocation = lookPath "solaar" -}}
+{{- end -}}
+{{- $kded6Location := findExecutable "kded6" $paths -}}
+{{- if eq $kded6Location "" -}}
+  {{- $kded6Location = lookPath "kded6" -}}
+{{- end -}}
+{{- $kdeconnectIndicatorLocation := findExecutable "kdeconnect-indicator" $paths -}}
+{{- if eq $kdeconnectIndicatorLocation "" -}}
+  {{- $kdeconnectIndicatorLocation = lookPath "kdeconnect-indicator" -}}
+{{- end -}}
+{{- $nmAppletLocation := findExecutable "nm-applet" $paths -}}
+{{- if eq $nmAppletLocation "" -}}
+  {{- $nmAppletLocation = lookPath "nm-applet" -}}
+{{- end -}}
+
 {{- $anytypeLocation := findExecutable "Anytype.AppImage" $paths -}}
 {{- if eq $anytypeLocation "" -}}
   {{- $anytypeLocation = lookPath "Anytype.AppImage" -}}
@@ -463,6 +480,18 @@
 {{- if not (stat $swaymsgLocation ) -}}
         {{- writeToStdout "Can't find swaymsg \n" -}}
 {{- end -}}
+{{- if not (stat $solaarLocation ) -}}
+        {{- writeToStdout "Can't find solaar \n" -}}
+{{- end -}}
+{{- if not (stat $kded6Location ) -}}
+        {{- writeToStdout "Can't find kded6 \n" -}}
+{{- end -}}
+{{- if not (stat $kdeconnectIndicatorLocation ) -}}
+        {{- writeToStdout "Can't find kdeconnect-indicator \n" -}}
+{{- end -}}
+{{- if not (stat $nmAppletLocation ) -}}
+        {{- writeToStdout "Can't find nm-applet \n" -}}
+{{- end -}}
 
 {{- if not (stat $anytypeLocation ) -}}
         {{- writeToStdout "Can't find Anytype.AppImage \n" -}}
@@ -520,6 +549,10 @@
         hyprpickerLocation="{{$hyprpickerLocation}}"
         hyprshotLocation="{{$hyprshotLocation}}"
         swaymsgLocation="{{$swaymsgLocation}}"
+        solaarLocation="{{$solaarLocation}}"
+        kded6Location="{{$kded6Location}}"
+        kdeconnectIndicatorLocation="{{$kdeconnectIndicatorLocation}}"
+        nmAppletLocation="{{$nmAppletLocation}}"
         chromeLocation="{{$chromeLocation}}"
         anytypeLocation="{{$anytypeLocation}}"
         wofiLocation="{{$wofiLocation}}"

--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -41,6 +41,10 @@
   {{- $popupTerm = .xtermLocation -}}
 {{- end -}}
 {{- $anytype := .anytypeLocation -}}
+{{- $solaar := .solaarLocation -}}
+{{- $kded6 := .kded6Location -}}
+{{- $kdeconnectIndicator := .kdeconnectIndicatorLocation -}}
+{{- $nmApplet := .nmAppletLocation -}}
 
 # ------------------------
 # Monitors (customize names + positions)
@@ -257,10 +261,18 @@ exec-once = waybar
 exec-once = set-wallpaper
 exec-once = dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP=hyprland
 exec-once = {{$clipse}} -listen
+{{- if ne $solaar "" -}}
 exec-once = solaar -w hide
+{{- end -}}
+{{- if ne $kded6 "" -}}
 exec-once = kded6
+{{- end -}}
+{{- if ne $kdeconnectIndicator "" -}}
 exec-once = kdeconnect-indicator
+{{- end -}}
+{{- if ne $nmApplet "" -}}
 exec-once = nm-applet
+{{- end -}}
 #exec-once = [workspace special:music silent] flatpak run com.spotify.Client
 windowrulev2 = workspace special:music, class:^(Spotify|spotify|org.spotify.Client|com.spotify.Client)$
 #exec-once = [workspace special:terminal silent] {{$terminal}}


### PR DESCRIPTION
## Summary
- detect solaar, kded6, kdeconnect-indicator, nm-applet in chezmoi config
- only autostart these programs in Hyprland when present

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`

------
https://chatgpt.com/codex/tasks/task_e_6886eb80fcec832f86fa9a6869be11d5