### PR TITLE
Add layout cycling shortcut

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -57,7 +57,7 @@ general {
     border_size = 2                       # window border width
     col.active_border = rgba(135affcc)    # active window border color
     col.inactive_border = rgba(323232cc)  # inactive window border
-    layout = dwindle                      # bsp-like tiling
+    layout = master                       # master tiling
 }
 
 env = LIBVA_DRIVER_NAME,nvidia
@@ -109,6 +109,8 @@ bind = CTRL SUPER_L, T, exec, {{$terminal}}
 # Terminal as alternate: Meta+Return
 bind = SUPER_L, RETURN, exec, {{$terminal}}
 #bind = SUPER_R, RETURN, exec, {{$terminal}}
+# Toggle layout: Meta+Y
+bind = SUPER_L, Y, exec, hypr-cycle-layout
 bind = SUPER_L, SPACE, exec, {{$launcher}}
 #bind = SUPER_R, SPACE, exec, {{$launcher}}
 # Clipboard history: Meta+V

--- a/dot_local/bin/executable_hypr-cycle-layout
+++ b/dot_local/bin/executable_hypr-cycle-layout
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cycle through Hyprland layouts
+layouts=(master dwindle)
+current=$(hyprctl getoption general:layout | awk '/str/ {print $2}')
+for i in "${!layouts[@]}"; do
+  if [[ "${layouts[$i]}" == "$current" ]]; then
+    next_index=$(( (i + 1) % ${#layouts[@]} ))
+    hyprctl keyword general:layout "${layouts[$next_index]}"
+    exit 0
+  fi
+done
+
+# If current layout not in list, set to first
+hyprctl keyword general:layout "${layouts[0]}"


### PR DESCRIPTION
## Summary
- add `hypr-cycle-layout` helper script in `.local/bin`
- bind Meta+Y to `hypr-cycle-layout` to switch layouts
- set the default tiling layout to `master`
- rename script with chezmoi executable prefix

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: template error `playerctlPlayer`)*

------
https://chatgpt.com/codex/tasks/task_e_6886b547b620832f8d0d5289a39ff636