### PR TITLE
Fix undefined playerctlPlayer in Hyprland config

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -39,10 +39,7 @@
 {{- $kdeconnectIndicator := .kdeconnectIndicatorLocation -}}
 {{- $nmApplet := .nmAppletLocation -}}
 
-{{- $playerctlPlayer := "spotify" -}}
-{{- if ne .playerctlPlayer "" -}}
-  {{- $playerctlPlayer = .playerctlPlayer -}}
-{{- end -}}
+{{- $playerctlPlayer := (index . "playerctlPlayer" | default "spotify") -}}
 
 # ------------------------
 # Monitors (customize names + positions)


### PR DESCRIPTION
## Summary
- avoid failure when `.playerctlPlayer` isn't defined by using `index` with `default` in `hyprland.conf.tmpl`

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(fails: map has no entry for key "playerctlPlayer")*


------
https://chatgpt.com/codex/tasks/task_e_6886f0f08bc4832fae56532d1ac8c425