### PR TITLE
Route Alacritty to terminal workspace

### DIFF
--- a/dot_config/hypr/hyprland.conf.tmpl
+++ b/dot_config/hypr/hyprland.conf.tmpl
@@ -285,9 +285,10 @@ exec-once = nm-applet
 {{- end -}}
 #exec-once = [workspace special:music silent] flatpak run com.spotify.Client
 windowrulev2 = workspace special:music, class:^(Spotify|spotify|org.spotify.Client|com.spotify.Client)$
-#exec-once = [workspace special:terminal silent] {{$terminal}}
+exec-once = [workspace special:terminal silent] {{$terminal}}
 {{- if ne $anytype "" -}}
 #exec-once = [workspace special:anytype silent] {{$anytype}}
 {{- end -}}
+windowrulev2 = workspace special:terminal, class:^(Alacritty)$
 windowrulev2 = workspace special:anytype, class:^(Anytype)$
 windowrulev2 = center, class:^(zenity|kdialog)$


### PR DESCRIPTION
## Summary
- Start Alacritty in the dedicated terminal workspace on Hyprland
- Force Alacritty windows onto the terminal special workspace

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4` *(missing gh, flutter, git-tag-inc, rar, 7z, xinput, grim, slurp, wl-copy, hyprpicker, hyprshot, wf-recorder, swaymsg, solaar, kded6, kdeconnect-indicator, nm-applet, Anytype.AppImage)*

------
https://chatgpt.com/codex/tasks/task_e_68904851faa4832fbffb51967f926702