### PR TITLE
Include JetBrains Toolbox scripts in PATH

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -29,6 +29,7 @@
           (joinPath .chezmoi.homeDir "/.cache/npm")
         -}}
         {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
+        {{- $paths = append $paths (joinPath .chezmoi.homeDir "/Library/Application Support/JetBrains/Toolbox/scripts") -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "xterm" "linux" "vt100" -}}
 #{{ else if eq .chezmoi.os "linux" }} Linux
@@ -47,6 +48,7 @@
           (joinPath .chezmoi.homeDir "/.cache/npm")
         -}}
         {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.dotnet/tools") -}}
+        {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.local/share/JetBrains/Toolbox/scripts") -}}
         {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.local/share/flatpak/exports/bin") -}}
         {{- $paths = append $paths "/var/lib/flatpak/exports/bin" -}}
         {{- $paths = append $paths "/usr/games/bin" -}}


### PR DESCRIPTION
## Summary
- include JetBrains Toolbox script directories in PATH for macOS and Linux

## Testing
- `yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4`


------
https://chatgpt.com/codex/tasks/task_e_68b3f4ecb06c832fbc63e070c94c4d14