### PR TITLE
Add PipeWire RAOP discovery configuration

### DIFF
--- a/dot_config/pipewire/pipewire.conf.d/my-raop-discover.conf
+++ b/dot_config/pipewire/pipewire.conf.d/my-raop-discover.conf
@@ -1,0 +1,36 @@
+context.modules = [
+  { name = libpipewire-module-raop-discover
+    args = {
+      #roap.discover-local = false;
+      #raop.latency.ms = 1000
+      stream.rules = [
+        { matches = [
+            { raop.ip = "~.*"
+              #raop.port = 1000
+              #raop.name = ""
+              #raop.hostname = ""
+              #raop.domain = ""
+              #raop.device = ""
+              #raop.transport = "udp" | "tcp"
+              #raop.encryption.type = "none" | "RSA" | "auth_setup" | "fp_sap25"
+              #raop.audio.codec = "PCM" | "ALAC" | "AAC" | "AAC-ELD"
+              #audio.channels = 2
+              #audio.format = "S16" | "S24" | "S32"
+              #audio.rate = 44100
+              #device.model = ""
+            }
+          ]
+          actions = {
+            create-stream = {
+              #raop.password = ""
+              stream.props = {
+                #target.object = ""
+                #media.class = "Audio/Sink"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add a PipeWire RAOP discovery configuration template with customizable stream and device parameters

## Testing
- yes "" | sh -c "$(curl -fsLS get.chezmoi.io)" -- init --no-tty --debug --apply arran4 *(fails: chezmoi reports `dot_config/quickshell: unknown external type: git`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd456d1a9c832fbfb88bd9b8f4be56