### PR TITLE
fix: use clone.args instead of ref in chezmoiexternal for git-repo

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -1,4 +1,4 @@
 [".config/quickshell"]
 type = "git-repo"
 url = "https://github.com/caelestia-dots/shell.git"
-ref = "v1.3.3"
+clone.args = ["-b", "v1.3.3"]


### PR DESCRIPTION
Replaced the invalid `ref` field in `.chezmoiexternal.toml` with `clone.args` to fix a strict mode evaluation failure during `chezmoi init`.

---
*PR created automatically by Jules for task [4050591188082106526](https://jules.google.com/task/4050591188082106526) started by @arran4*