### PR TITLE
Fix: prevent empty git editor/tool values in gitconfig template

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -29,7 +29,7 @@
   {{- else }}
   editor = notepad
   {{- end }}
-{{- else }}
+{{- else if ne $editTool "" }}
   editor = {{ $editTool }}
 {{- end }}
   excludesfile = {{ .chezmoi.homeDir }}/.config/git/ignore
@@ -114,7 +114,8 @@
   conflictstyle = zdiff3
 {{- else if ne $mergeTool "" }}
   conflictstyle = diff3 # show original content before conflicts
-{{- else }}
+{{- end }}
+{{- if ne $mergeTool "" }}
   tool = {{ $mergeTool }}
 {{- end }}
 
@@ -128,7 +129,9 @@
 {{end}}
 
 [diff]
+{{- if ne $diffTool "" }}
   tool = {{ $diffTool }}
+{{- end }}
   colorMoved = default
 
 [difftool]


### PR DESCRIPTION
When variables like `$editTool`, `$mergeTool`, or `$diffTool` evaluate to empty strings in `.gitconfig.tmpl`, the template outputs invalid git config lines like `editor = ` or `tool = ` (in `[merge]` and `[diff]`). 

This empty assignment overrides Git's system defaults (such as falling back to `vi` or `nano`) and causes `git var GIT_EDITOR` to fail or return nothing. This breaks external tools or workflows that rely on standard git editor behavior.

This fix correctly wraps `editor` and `tool` assignments in `{{- if ne $... "" }}` blocks, ensuring that they are only printed if a valid tool was actually resolved by `chezmoi`. We also fixed a logical issue in the `[merge]` block where `tool` was only being set if the string *was* empty.

---
*PR created automatically by Jules for task [14173101488522108270](https://jules.google.com/task/14173101488522108270) started by @arran4*