### PR TITLE
Add Konsole Quick Commands configuration

### DIFF
--- a/dot_config/konsolequickcommandsconfig
+++ b/dot_config/konsolequickcommandsconfig
@@ -58,9 +58,9 @@ command=sudo emerge --sync && sudo emerge -avuDNU --with-bdeps=y @world --keep-g
 name=emerge sync world ask upgrade newuse with bdeps keepgoing notify
 tooltip=
 
-[gentoo][emerge world ask deep new-use new upgarde keep going and notify afterwards]
+[gentoo][emerge world ask deep new-use new upgrade keep going and notify afterwards]
 command=sudo emerge @world -vauDNU --keep-going=y ; notify-send "Emerge world done"\n
-name=emerge world ask deep new-use new upgarde keep going and notify afterwards
+name=emerge world ask deep new-use new upgrade keep going and notify afterwards
 tooltip=
 
 [gentoo][emerge world update ask]

--- a/dot_config/konsolequickcommandsconfig
+++ b/dot_config/konsolequickcommandsconfig
@@ -1,0 +1,104 @@
+[dev][gh release push]
+command=gh-release.sh patch
+name=gh release push
+tooltip=
+
+[dev][git add ammend commit no edit tag release push tags and force push]
+command=git add . && git commit --amend --no-edit && git-tag-inc release && git push --tags && git push --force
+name=git add ammend commit no edit tag release push tags and force push
+tooltip=
+
+[dev][git-tag-inc release push]
+command=git-tag-inc release && git push --tags
+name=git-tag-inc release push
+tooltip=
+
+[dev/appengine][arran4com datastore emulator]
+command=gcloud beta emulators datastore start --project arran4com
+name=arran4com datastore emulator
+tooltip=
+
+[dev/flutter][flutter analyze]
+command=flutter analyze
+name=flutter analyze
+tooltip=
+
+[dev/flutter][flutter run builder]
+command=flutter pub run build_runner build
+name=flutter run builder
+tooltip=
+
+[dev/go][go lint]
+command=golangci-lint run
+name=go lint
+tooltip=
+
+[dev/go][go mod tidy]
+command=go mod tidy
+name=go mod tidy
+tooltip=
+
+[dev/go][go test vet fix lint format]
+command=go test ./... && go vet ./... && go fix ./... && golangci-lint run && go fmt ./...
+name=go test vet fix lint format
+tooltip=
+
+[download][wget continue list.txt notify]
+command=wget -I --continue --input list.txt --content-disposition --trust-server-names --retry-connrefused; notify-send "wget"\n
+name=wget continue list.txt notify
+tooltip=
+
+[gentoo][config dispatch]
+command=sudo dispatch-conf
+name=config dispatch
+tooltip=
+
+[gentoo][emerge sync world ask upgrade newuse with bdeps keepgoing notify]
+command=sudo emerge --sync && sudo emerge -avuDNU --with-bdeps=y @world --keep-going=y; notify-send "Emerge world done"\n
+name=emerge sync world ask upgrade newuse with bdeps keepgoing notify
+tooltip=
+
+[gentoo][emerge world ask deep new-use new upgarde keep going and notify afterwards]
+command=sudo emerge @world -vauDNU --keep-going=y ; notify-send "Emerge world done"\n
+name=emerge world ask deep new-use new upgarde keep going and notify afterwards
+tooltip=
+
+[gentoo][emerge world update ask]
+command=sudo emerge -vau @world
+name=emerge world update ask
+tooltip=
+
+[gentoo][emerge world update new-use new-deps deep ask keepgoing]
+command=sudo emerge -vauUDN @world --keep-going=y
+name=emerge world update new-use new-deps deep ask keepgoing
+tooltip=
+
+[gentoo][gentoo sync]
+command=sudo emerge --sync
+name=gentoo sync
+tooltip=
+
+[system][chezmoi update apply init]
+command=chezmoi update --apply --init
+name=chezmoi update apply init
+tooltip=
+
+[system][start cups]
+command=systemctl start cups
+name=start cups
+tooltip=
+
+[system][start docker]
+command=systemctl start docker
+name=start docker
+tooltip=
+
+[system][start mariadb]
+command=systemctl start mariadb
+name=start mariadb
+tooltip=
+
+[system][start ollama]
+command=systemctl start ollama
+name=start ollama
+tooltip=

--- a/dot_config/konsolequickcommandsconfig
+++ b/dot_config/konsolequickcommandsconfig
@@ -44,7 +44,7 @@ name=go test vet fix lint format
 tooltip=
 
 [download][wget continue list.txt notify]
-command=wget -I --continue --input list.txt --content-disposition --trust-server-names --retry-connrefused; notify-send "wget"\n
+command=wget --continue --input-file=list.txt --content-disposition --trust-server-names --retry-connrefused; notify-send "wget"
 name=wget continue list.txt notify
 tooltip=
 


### PR DESCRIPTION
Resolves issue by adding the requested `~/.config/konsolequickcommandsconfig` payload for managing Konsole's Quick Commands plugin.

Added file:
- `dot_config/konsolequickcommandsconfig`

---
*PR created automatically by Jules for task [3471236948531877642](https://jules.google.com/task/3471236948531877642) started by @arran4*