### PR TITLE
Automate spellcheck configuration based on tool presence

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -7,8 +7,7 @@
 {{- $headless := promptBool "headless" $headlessGuess -}}
 {{- $gpgconfigured := promptBool "gpgconfigured" $gpgconfiguredGuess -}}
 {{- $autoGit := promptBool "auto git?" true -}}
-{{- $spellcheckGuess := true -}}
-{{- $spellcheck := promptBool "spellcheck" $spellcheckGuess -}}
+{{- $spellcheck := or (lookPath "hunspell" | not | not) (lookPath "aspell" | not | not) (lookPath "ispell" | not | not) -}}
 {{- $gitUserName := promptString "git user.name" (trim (output "sh" "-c" "git config --get user.name 2>/dev/null || getent passwd $(id -un) | cut -d ':' -f5 | cut -d ',' -f1 || getent passwd $(id -un) | cut -d ':' -f1")) -}}
 {{- $gitUserEmail := promptString "git user.email" (trim (output "sh" "-c" "git config --get user.email 2>/dev/null || true")) -}}
 {{- $generatedTime := now | date "2006-01-02 15:04:05 -0700" -}}


### PR DESCRIPTION
Replaced the interactive `promptBool` for `spellcheck` in `.chezmoi.toml.tmpl` with an automated check. The configuration now uses `lookPath` to detect the presence of `hunspell`, `aspell`, or `ispell` executables, automatically enabling the `spellcheck` flag if any are found. This streamlines the initialization process by reducing manual prompts.

---
*PR created automatically by Jules for task [4572349562026552516](https://jules.google.com/task/4572349562026552516) started by @arran4*