### PR TITLE
Add Junie CLI to Debian dev container

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,3 @@ run:
 ```sh
 sudo update-alternatives --set x-terminal-emulator /usr/bin/foot
 ```
-
-## AI Assistants & Agents
-
-This environment includes support for several AI assistants:
-- [Junie](https://junie.jetbrains.com/)

--- a/README.md
+++ b/README.md
@@ -151,3 +151,7 @@ run:
 sudo update-alternatives --set x-terminal-emulator /usr/bin/foot
 ```
 
+## AI Assistants & Agents
+
+This environment includes support for several AI assistants:
+- [Junie](https://junie.jetbrains.com/)

--- a/containers/dev-dotfiles-debian/Dockerfile
+++ b/containers/dev-dotfiles-debian/Dockerfile
@@ -151,4 +151,7 @@ RUN set -euxo pipefail \
   && go version \
   && git --version
 
+RUN set -euxo pipefail \
+  && curl -fsSL https://junie.jetbrains.com/install.sh | bash
+
 ENTRYPOINT ["/usr/bin/zsh", "-l"]

--- a/containers/dev-dotfiles-debian/Dockerfile
+++ b/containers/dev-dotfiles-debian/Dockerfile
@@ -152,6 +152,7 @@ RUN set -euxo pipefail \
   && git --version
 
 RUN set -euxo pipefail \
-  && curl -fsSL https://junie.jetbrains.com/install.sh | bash
+  && curl -fsSL https://junie.jetbrains.com/install.sh | bash \
+  && junie --version
 
 ENTRYPOINT ["/usr/bin/zsh", "-l"]


### PR DESCRIPTION
Adds the Junie CLI to the Debian development container by executing the official installation script.

---
*PR created automatically by Jules for task [13119977536383135396](https://jules.google.com/task/13119977536383135396) started by @arran4*