### PR TITLE
Switch songmean.sh search to Perplexity

### DIFF
--- a/dot_local/bin/executable_songmean.sh.tmpl
+++ b/dot_local/bin/executable_songmean.sh.tmpl
@@ -68,7 +68,7 @@ urlencode() {
 {{- end }}
 QUERY=$({{ $playerctlCmd }} metadata --format '{{ "{{" }} artist {{ "}}" }} - {{ "{{" }} title {{ "}}" }}. Song lyrics, meaning, context and analysis' -p spotify 2>/dev/null)
 METADATA=$(urlencode "$QUERY")
-URL="https://grok.com/?q=$METADATA"
+URL="https://www.perplexity.ai/search?q=$METADATA"
 
 # Execute
 "$BROWSER_CMD" "$URL"

--- a/dot_local/share/applications/songmean.desktop.tmpl
+++ b/dot_local/share/applications/songmean.desktop.tmpl
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Song Meanings
-Comment=Search for song meanings on Grok
+Comment=Search for song meanings on Perplexity
 Exec={{ .chezmoi.homeDir }}/.local/bin/songmean.sh
 Icon=system-search
 Terminal=false


### PR DESCRIPTION
Switched the default search engine in `songmean.sh` from Grok to Perplexity as requested by the user.

- Updated the `URL` variable in `dot_local/bin/executable_songmean.sh.tmpl` to construct a Perplexity search URL (`https://www.perplexity.ai/search?q=...`) instead of Grok.

---
*PR created automatically by Jules for task [15659168506453186254](https://jules.google.com/task/15659168506453186254) started by @arran4*