### PR TITLE
Configure GH_PAGER to use less

### DIFF
--- a/.chezmoitemplates/common-misc-env.tmpl
+++ b/.chezmoitemplates/common-misc-env.tmpl
@@ -19,19 +19,21 @@ export WATCH=root
 	# Pager IS less
 	export PAGER={{(index . "nvimpagerLocation")}}
 	export DELTA_PAGER=less
+{{-   if stat (index . "lessLocation") }}
+	export GH_PAGER={{(index . "lessLocation")}}
+{{-   end }}
 {{ else if stat (index . "vimpagerLocation") -}}
 	# Pager IS less
 	export PAGER={{(index . "vimpagerLocation")}}
 	export DELTA_PAGER=less
+{{-   if stat (index . "lessLocation") }}
+	export GH_PAGER={{(index . "lessLocation")}}
+{{-   end }}
 {{ else if stat (index . "lessLocation") -}}
 	# Pager IS less
 	export PAGER={{(index . "lessLocation")}}
 {{- else -}}
 	# No less found!
-{{- end }}
-
-{{ if stat (index . "lessLocation") -}}
-	export GH_PAGER={{(index . "lessLocation")}}
 {{- end }}
 
 # set variable identifying the chroot you work in (used in the prompt below)

--- a/.chezmoitemplates/common-misc-env.tmpl
+++ b/.chezmoitemplates/common-misc-env.tmpl
@@ -30,6 +30,10 @@ export WATCH=root
 	# No less found!
 {{- end }}
 
+{{ if stat (index . "lessLocation") -}}
+	export GH_PAGER={{(index . "lessLocation")}}
+{{- end }}
+
 # set variable identifying the chroot you work in (used in the prompt below)
 if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
     debian_chroot=$(cat /etc/debian_chroot)


### PR DESCRIPTION
Configures GitHub CLI (`gh`) to use `less` as the default pager.

### Changes
- Modifies `.chezmoitemplates/common-misc-env.tmpl` to explicitly export `GH_PAGER` pointing to the `lessLocation` if `less` is installed.
- Excludes setting `GH_EDITOR=less` to avoid breaking `gh` commands that expect a functional text editor (like creating PRs).

---
*PR created automatically by Jules for task [856307998023107720](https://jules.google.com/task/856307998023107720) started by @arran4*