### PR TITLE
Set GOBIN to ~/bin

### DIFF
--- a/dot_config/go/env.tmpl
+++ b/dot_config/go/env.tmpl
@@ -1,1 +1,2 @@
 GOPATH={{ .chezmoi.homeDir }}/.go
+GOBIN={{ .chezmoi.homeDir }}/bin


### PR DESCRIPTION
Fixes an issue where GOBIN was not configured to the user's `~/bin` directory by appending it to the standard go env template file managed by chezmoi.

---
*PR created automatically by Jules for task [18053654521822239618](https://jules.google.com/task/18053654521822239618) started by @arran4*