### PR TITLE
fix: prevent empty gh credential sections in gitconfig

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -42,14 +42,14 @@
 [rerere]
   enabled = 1
 
-{{ if ne (index . "ghLocation") "" }}
+{{ if index . "ghLocation" }}
 [credential "https://github.com"]
   useHttpPath = true
   helper =
   helper = !{{ index . "ghLocation" }} auth git-credential
 {{ end }}
 
-{{ if ne (index . "ghLocation") "" }}
+{{ if index . "ghLocation" }}
 [credential "https://gist.github.com"]
   helper =
   helper = !{{ index . "ghLocation" }} auth git-credential

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -42,15 +42,15 @@
 [rerere]
   enabled = 1
 
+{{ if ne (index . "ghLocation") "" }}
 [credential "https://github.com"]
   useHttpPath = true
-{{ if ne (index . "ghLocation") "" }}
   helper =
   helper = !{{ index . "ghLocation" }} auth git-credential
 {{ end }}
 
-[credential "https://gist.github.com"]
 {{ if ne (index . "ghLocation") "" }}
+[credential "https://gist.github.com"]
   helper =
   helper = !{{ index . "ghLocation" }} auth git-credential
 {{ end }}


### PR DESCRIPTION
This pull request addresses an issue where empty credential section headers (`[credential "https://github.com"]` and `https://gist.github.com`) were being rendered in the generated `~/.gitconfig` file if the GitHub CLI (`gh`) was not found or configured in `.chezmoi.toml.tmpl`.

### Changes made:
* Modified `dot_gitconfig.tmpl` to move the `{{ if ne (index . "ghLocation") "" }}` conditional so that it wraps the entire credential block for both GitHub and Gist, rather than just the inner `helper =` logic.

### Verification:
* Verified locally via `chezmoi execute-template` that the Git configuration no longer emits orphaned `[credential "https://github.com"]` blocks when `gh` is unavailable.

---
*PR created automatically by Jules for task [18308398881427281795](https://jules.google.com/task/18308398881427281795) started by @arran4*