### PR TITLE
feat(macos): configure screenshot location to Pictures/Screenshots

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -1,12 +1,19 @@
 {{- if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 
+logger -t chezmoi-macos-defaults "Starting macOS screenshot configuration script"
+
 # Create the Screenshots directory if it doesn't exist
 mkdir -p "${HOME}/Pictures/Screenshots"
+logger -t chezmoi-macos-defaults "Created/verified Screenshots directory at ${HOME}/Pictures/Screenshots"
 
 # Save screenshots to the Pictures/Screenshots directory
 defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
+logger -t chezmoi-macos-defaults "Updated com.apple.screencapture location to ${HOME}/Pictures/Screenshots"
 
 # Ensure the changes take effect
 killall SystemUIServer 2>/dev/null || true
+logger -t chezmoi-macos-defaults "Restarted SystemUIServer to apply changes"
+
+logger -t chezmoi-macos-defaults "Finished macOS screenshot configuration script"
 {{- end -}}

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -8,5 +8,5 @@ mkdir -p "${HOME}/Pictures/Screenshots"
 defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
 
 # Ensure the changes take effect
-killall SystemUIServer
+killall SystemUIServer 2>/dev/null || true
 {{- end -}}

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -1,0 +1,12 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+# Create the Screenshots directory if it doesn't exist
+mkdir -p "${HOME}/Pictures/Screenshots"
+
+# Save screenshots to the Pictures/Screenshots directory
+defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
+
+# Ensure the changes take effect
+killall SystemUIServer
+{{- end -}}


### PR DESCRIPTION
This PR adds a run-once script for macOS systems managed via chezmoi to automatically configure the system screenshot location to be `~/Pictures/Screenshots`, effectively changing it from the default Desktop location.

Changes:
- Added `.chezmoiscripts/run_once_macos-defaults.sh.tmpl`
- Wrapped the script content with `{{- if eq .chezmoi.os "darwin" -}}` to ensure it only runs on macOS.
- Created the target directory using `mkdir -p`.
- Configured the defaults using `defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"`.
- Restarted `SystemUIServer` to apply the setting.

---
*PR created automatically by Jules for task [7354335212898417899](https://jules.google.com/task/7354335212898417899) started by @arran4*