### PR TITLE
feat(macos): default screenshot format to PNG

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -11,6 +11,10 @@ logger -t chezmoi-macos-defaults "Created/verified Screenshots directory at ${HO
 defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
 logger -t chezmoi-macos-defaults "Updated com.apple.screencapture location to ${HOME}/Pictures/Screenshots"
 
+# Save screenshots in PNG format (other options: BMP, GIF, JPG, PDF, TIFF)
+defaults write com.apple.screencapture type -string "png"
+logger -t chezmoi-macos-defaults "Updated com.apple.screencapture type to png"
+
 # Ensure the changes take effect
 killall SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted SystemUIServer to apply changes"


### PR DESCRIPTION
This PR updates `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` to ensure macOS screenshots are saved in PNG format by default using the `defaults write com.apple.screencapture type -string "png"` command. This change aligns with the jessfraz/dotfiles reference provided.

---
*PR created automatically by Jules for task [539334738248603645](https://jules.google.com/task/539334738248603645) started by @arran4*