### PR TITLE
fix(macos): add missing comment for DisableAllAnimations

### DIFF
--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -26,6 +26,8 @@ defaults write com.apple.dock show-recents -bool false
 defaults write com.apple.finder ShowPathbar -bool true
 defaults write com.apple.finder ShowStatusBar -bool true
 defaults write com.apple.finder QuitMenuItem -bool true
+
+# Finder: disable window animations and Get Info animations
 defaults write com.apple.finder DisableAllAnimations -bool true
 
 # Save screenshots to a dedicated directory


### PR DESCRIPTION
Add missing comment `# Finder: disable window animations and Get Info animations` immediately before the `defaults write com.apple.finder DisableAllAnimations -bool true` line in `dot_local/bin/macos_defaults.sh`, matching the upstream `macos-defaults` script.

Fixes issue based on lines 229-230 from https://github.com/jessfraz/dotfiles/blob/main/bin/macos-defaults

---
*PR created automatically by Jules for task [2678955207728857569](https://jules.google.com/task/2678955207728857569) started by @arran4*