### PR TITLE
Set macOS Finder new window default to Documents

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -37,6 +37,13 @@ logger -t chezmoi-macos-defaults "Updated com.apple.finder QuitMenuItem to true"
 defaults write com.apple.finder DisableAllAnimations -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder DisableAllAnimations to true"
 
+# Set Documents as the default location for new Finder windows
+defaults write com.apple.finder NewWindowTarget -string "PfLo"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to PfLo"
+
+defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTargetPath to file://${HOME}/Documents/"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -30,6 +30,10 @@ defaults write com.apple.finder QuitMenuItem -bool true
 # Finder: disable window animations and Get Info animations
 defaults write com.apple.finder DisableAllAnimations -bool true
 
+# Set Documents as the default location for new Finder windows
+defaults write com.apple.finder NewWindowTarget -string "PfLo"
+defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"
+
 # Save screenshots to a dedicated directory
 screenshots_dir="${HOME}/Screenshots/mac defaults"
 mkdir -p "$screenshots_dir"


### PR DESCRIPTION
Changes the default macOS Finder target location from `Desktop` or default to `Documents`.

Updates made:
- Added `com.apple.finder NewWindowTarget` "PfLo" to `.chezmoiscripts/run_once_macos-defaults.sh.tmpl`
- Added `com.apple.finder NewWindowTargetPath` to `"file://${HOME}/Documents/"` to `.chezmoiscripts/run_once_macos-defaults.sh.tmpl`
- Made equivalent changes to `dot_local/bin/macos_defaults.sh` for parity.

---
*PR created automatically by Jules for task [15338217284791790522](https://jules.google.com/task/15338217284791790522) started by @arran4*