### PR TITLE
feat(macos): configure Finder to show hidden files by default

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -37,6 +37,10 @@ logger -t chezmoi-macos-defaults "Updated com.apple.finder QuitMenuItem to true"
 defaults write com.apple.finder DisableAllAnimations -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder DisableAllAnimations to true"
 
+# Finder: show hidden files by default
+defaults write com.apple.finder AppleShowAllFiles -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.finder AppleShowAllFiles to true"
+
 # Set Documents as the default location for new Finder windows
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to PfLo"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -30,6 +30,9 @@ defaults write com.apple.finder QuitMenuItem -bool true
 # Finder: disable window animations and Get Info animations
 defaults write com.apple.finder DisableAllAnimations -bool true
 
+# Finder: show hidden files by default
+defaults write com.apple.finder AppleShowAllFiles -bool true
+
 # Set Documents as the default location for new Finder windows
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
 defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"


### PR DESCRIPTION
This PR adds the macOS defaults configuration to make Finder show hidden files by default.

This change is based on the [jessfraz/dotfiles configuration](https://github.com/jessfraz/dotfiles/blob/main/bin/macos-defaults#L243-L244) and updates both the managed `chezmoi` script and the standalone local helper script.

Affected files:
- `.chezmoiscripts/run_once_macos-defaults.sh.tmpl`
- `dot_local/bin/macos_defaults.sh`

---
*PR created automatically by Jules for task [7010728479801732993](https://jules.google.com/task/7010728479801732993) started by @arran4*