### PR TITLE
feat(macos): add more Finder defaults to configuration

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -52,6 +52,8 @@ logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXShowPosixPathInTit
 # Keep folders on top when sorting by name
 defaults write com.apple.finder _FXSortFoldersFirst -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirst to true"
+defaults write com.apple.finder _FXSortFoldersFirstOnDesktop -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirstOnDesktop to true"
 
 # When performing a search, search the current folder by default
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -41,6 +41,26 @@ logger -t chezmoi-macos-defaults "Updated com.apple.finder DisableAllAnimations 
 defaults write com.apple.finder AppleShowAllFiles -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder AppleShowAllFiles to true"
 
+# Finder: show all filename extensions
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowAllExtensions to true"
+
+# Display full POSIX path as Finder window title
+defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXShowPosixPathInTitle to true"
+
+# Keep folders on top when sorting by name
+defaults write com.apple.finder _FXSortFoldersFirst -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirst to true"
+
+# When performing a search, search the current folder by default
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder FXDefaultSearchScope to SCcf"
+
+# Disable the warning when changing a file extension
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+logger -t chezmoi-macos-defaults "Updated com.apple.finder FXEnableExtensionChangeWarning to false"
+
 # Set Documents as the default location for new Finder windows
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to PfLo"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -41,6 +41,7 @@ defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
 
 # Keep folders on top when sorting by name
 defaults write com.apple.finder _FXSortFoldersFirst -bool true
+defaults write com.apple.finder _FXSortFoldersFirstOnDesktop -bool true
 
 # When performing a search, search the current folder by default
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -33,6 +33,21 @@ defaults write com.apple.finder DisableAllAnimations -bool true
 # Finder: show hidden files by default
 defaults write com.apple.finder AppleShowAllFiles -bool true
 
+# Finder: show all filename extensions
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+
+# Display full POSIX path as Finder window title
+defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
+
+# Keep folders on top when sorting by name
+defaults write com.apple.finder _FXSortFoldersFirst -bool true
+
+# When performing a search, search the current folder by default
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+
+# Disable the warning when changing a file extension
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+
 # Set Documents as the default location for new Finder windows
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
 defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"


### PR DESCRIPTION
Adds several new Finder configurations based on Jess Frazelle's dotfiles to the macOS defaults scripts:
- Show all filename extensions
- Display full POSIX path as Finder window title
- Keep folders on top when sorting by name
- When performing a search, search the current folder by default
- Disable the warning when changing a file extension

Files modified:
- `.chezmoiscripts/run_once_macos-defaults.sh.tmpl`
- `dot_local/bin/macos_defaults.sh`

---
*PR created automatically by Jules for task [5189114151438886745](https://jules.google.com/task/5189114151438886745) started by @arran4*