### PR TITLE
feat(macos): prevent .DS_Store creation on network and USB volumes

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -70,6 +70,13 @@ logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to Pf
 defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTargetPath to file://${HOME}/Documents/"
 
+# Avoid creating .DS_Store files on network or USB volumes
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteNetworkStores to true"
+
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteUSBStores to true"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -58,5 +58,9 @@ screenshots_dir="${HOME}/Screenshots/mac defaults"
 mkdir -p "$screenshots_dir"
 defaults write com.apple.screencapture location "$screenshots_dir"
 
+# Avoid creating .DS_Store files on network or USB volumes
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
Updates macOS defaults scripts to replicate configurations that prevent the creation of `.DS_Store` files on network and USB volumes.

**Changes:**
- Modified `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` to add `DSDontWriteNetworkStores` and `DSDontWriteUSBStores` defaults write commands.
- Modified `dot_local/bin/macos_defaults.sh` to add the same commands.

These changes ensure both the automated chezmoi deployment and the standalone local execution apply these configurations correctly, keeping directories on remote and external media clean.

---
*PR created automatically by Jules for task [3676361056486003745](https://jules.google.com/task/3676361056486003745) started by @arran4*