### PR TITLE
feat(macos): configure Finder to automatically open for new volumes

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -77,6 +77,14 @@ logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteN
 defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteUSBStores to true"
 
+# Automatically open a new Finder window when a volume is mounted
+defaults write com.apple.frameworks.diskimages auto-open-ro-root -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-open-ro-root to true"
+defaults write com.apple.frameworks.diskimages auto-open-rw-root -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-open-rw-root to true"
+defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
+logger -t chezmoi-macos-defaults "Updated com.apple.finder OpenWindowForNewRemovableDisk to true"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -62,5 +62,10 @@ defaults write com.apple.screencapture location "$screenshots_dir"
 defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
 defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
 
+# Automatically open a new Finder window when a volume is mounted
+defaults write com.apple.frameworks.diskimages auto-open-ro-root -bool true
+defaults write com.apple.frameworks.diskimages auto-open-rw-root -bool true
+defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
This pull request updates the macOS system defaults scripts to configure Finder to automatically open a new window when volumes are mounted, matching a user-requested feature from jessfraz/dotfiles.

Summary of changes:
- Modified `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` to add `defaults write` commands and `logger` calls for `auto-open-ro-root`, `auto-open-rw-root`, and `OpenWindowForNewRemovableDisk`.
- Synchronized `dot_local/bin/macos_defaults.sh` with the same `defaults write` commands.
- Retained the existing `killall` command that already included `Finder`.

---
*PR created automatically by Jules for task [14887896305156849735](https://jules.google.com/task/14887896305156849735) started by @arran4*