### PR TITLE
Add macOS Finder icon and grid defaults

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -85,26 +85,37 @@ logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-o
 defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder OpenWindowForNewRemovableDisk to true"
 
+# Ensure parent dictionaries exist in com.apple.finder.plist
+for domain in DesktopViewSettings FK_StandardViewSettings StandardViewSettings; do
+  /usr/libexec/PlistBuddy -c "Add :${domain} dict" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null
+  /usr/libexec/PlistBuddy -c "Add :${domain}:IconViewSettings dict" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null
+done
+
+set_finder_pref() {
+  /usr/libexec/PlistBuddy -c "Add :$1 $2 $3" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :$1 $3" "$HOME/Library/Preferences/com.apple.finder.plist"
+}
+
 # Show item info near icons on the desktop and in other icon views
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:showItemInfo" "bool" "true"
+set_finder_pref "FK_StandardViewSettings:IconViewSettings:showItemInfo" "bool" "true"
+set_finder_pref "StandardViewSettings:IconViewSettings:showItemInfo" "bool" "true"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings showItemInfo to true"
 
 # Show item info to the right of the icons on the desktop
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:labelOnBottom false" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:labelOnBottom" "bool" "false"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist labelOnBottom to false"
 
 # Enable snap-to-grid for icons on the desktop and in other icon views
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:arrangeBy" "string" "grid"
+set_finder_pref "FK_StandardViewSettings:IconViewSettings:arrangeBy" "string" "grid"
+set_finder_pref "StandardViewSettings:IconViewSettings:arrangeBy" "string" "grid"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings arrangeBy to grid"
 
 # Increase grid spacing for icons on the desktop and in other icon views
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:gridSpacing" "integer" "100"
+set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
+set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
 
 # Ensure the changes take effect

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -85,6 +85,28 @@ logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-o
 defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder OpenWindowForNewRemovableDisk to true"
 
+# Show item info near icons on the desktop and in other icon views
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings showItemInfo to true"
+
+# Show item info to the right of the icons on the desktop
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:labelOnBottom false" ~/Library/Preferences/com.apple.finder.plist
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist labelOnBottom to false"
+
+# Enable snap-to-grid for icons on the desktop and in other icon views
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings arrangeBy to grid"
+
+# Increase grid spacing for icons on the desktop and in other icon views
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -67,5 +67,23 @@ defaults write com.apple.frameworks.diskimages auto-open-ro-root -bool true
 defaults write com.apple.frameworks.diskimages auto-open-rw-root -bool true
 defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
 
+# Show item info near icons on the desktop and in other icon views
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+
+# Show item info to the right of the icons on the desktop
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:labelOnBottom false" ~/Library/Preferences/com.apple.finder.plist
+
+# Enable snap-to-grid for icons on the desktop and in other icon views
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+
+# Increase grid spacing for icons on the desktop and in other icon views
+/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -67,23 +67,34 @@ defaults write com.apple.frameworks.diskimages auto-open-ro-root -bool true
 defaults write com.apple.frameworks.diskimages auto-open-rw-root -bool true
 defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
 
+# Ensure parent dictionaries exist in com.apple.finder.plist
+for domain in DesktopViewSettings FK_StandardViewSettings StandardViewSettings; do
+  /usr/libexec/PlistBuddy -c "Add :${domain} dict" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null
+  /usr/libexec/PlistBuddy -c "Add :${domain}:IconViewSettings dict" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null
+done
+
+set_finder_pref() {
+  /usr/libexec/PlistBuddy -c "Add :$1 $2 $3" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null || \
+  /usr/libexec/PlistBuddy -c "Set :$1 $3" "$HOME/Library/Preferences/com.apple.finder.plist"
+}
+
 # Show item info near icons on the desktop and in other icon views
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:showItemInfo true" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:showItemInfo" "bool" "true"
+set_finder_pref "FK_StandardViewSettings:IconViewSettings:showItemInfo" "bool" "true"
+set_finder_pref "StandardViewSettings:IconViewSettings:showItemInfo" "bool" "true"
 
 # Show item info to the right of the icons on the desktop
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:labelOnBottom false" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:labelOnBottom" "bool" "false"
 
 # Enable snap-to-grid for icons on the desktop and in other icon views
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:arrangeBy grid" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:arrangeBy" "string" "grid"
+set_finder_pref "FK_StandardViewSettings:IconViewSettings:arrangeBy" "string" "grid"
+set_finder_pref "StandardViewSettings:IconViewSettings:arrangeBy" "string" "grid"
 
 # Increase grid spacing for icons on the desktop and in other icon views
-/usr/libexec/PlistBuddy -c "Set :DesktopViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :FK_StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
-/usr/libexec/PlistBuddy -c "Set :StandardViewSettings:IconViewSettings:gridSpacing 100" ~/Library/Preferences/com.apple.finder.plist
+set_finder_pref "DesktopViewSettings:IconViewSettings:gridSpacing" "integer" "100"
+set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
+set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
Adds macOS system default configurations for Finder icon views and the desktop, replicating the behavior found in `jessfraz/dotfiles`.

Changes include:
- Showing item information near icons on the desktop and other icon views (`showItemInfo`).
- Positioning item info to the right of the icons on the desktop (`labelOnBottom false`).
- Enabling snap-to-grid for icons on the desktop and in other icon views (`arrangeBy grid`).
- Increasing grid spacing to 100 for desktop and icon views (`gridSpacing 100`).

Files modified:
- `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` (Includes `logger` statements)
- `dot_local/bin/macos_defaults.sh` (Kept in sync)

---
*PR created automatically by Jules for task [15572716888476761567](https://jules.google.com/task/15572716888476761567) started by @arran4*