### PR TITLE
feat(macos): Set Finder windows to use list view by default

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -23,7 +23,7 @@ defaults write com.apple.dock show-recents -bool false
 logger -t chezmoi-macos-defaults "Updated com.apple.dock show-recents to false"
 
 # Use list view in all Finder windows by default
-# Four-letter codes for the other view modes: `icnv`, `clmv`, `Flwv`
+# Four-letter codes for the other view modes: `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder FXPreferredViewStyle to Nlsv"
 

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -22,6 +22,11 @@ logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide to true"
 defaults write com.apple.dock show-recents -bool false
 logger -t chezmoi-macos-defaults "Updated com.apple.dock show-recents to false"
 
+# Use list view in all Finder windows by default
+# Four-letter codes for the other view modes: `icnv`, `clmv`, `Flwv`
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder FXPreferredViewStyle to Nlsv"
+
 # Finder: show path bar and status bar
 defaults write com.apple.finder ShowPathbar -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder ShowPathbar to true"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -23,7 +23,7 @@ defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock show-recents -bool false
 
 # Use list view in all Finder windows by default
-# Four-letter codes for the other view modes: `icnv`, `clmv`, `Flwv`
+# Four-letter codes for the other view modes: `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 
 # Finder: show path bar and status bar

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -22,6 +22,10 @@ esac
 defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock show-recents -bool false
 
+# Use list view in all Finder windows by default
+# Four-letter codes for the other view modes: `icnv`, `clmv`, `Flwv`
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
+
 # Finder: show path bar and status bar
 defaults write com.apple.finder ShowPathbar -bool true
 defaults write com.apple.finder ShowStatusBar -bool true


### PR DESCRIPTION
Adds a configuration to set the list view as the default for all Finder windows in macOS, integrating a setting from jessfraz/dotfiles.

Modifies `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` and `dot_local/bin/macos_defaults.sh` to include `defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"`.

---
*PR created automatically by Jules for task [14444689745690166024](https://jules.google.com/task/14444689745690166024) started by @arran4*