### PR TITLE
feat: unhide ~/Library and /Volumes on macOS

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -123,6 +123,14 @@ set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer"
 set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
 
+# Show the ~/Library folder
+chflags nohidden ~/Library
+logger -t chezmoi-macos-defaults "Unhid ~/Library"
+
+# Show the /Volumes folder
+sudo chflags nohidden /Volumes
+logger -t chezmoi-macos-defaults "Unhid /Volumes"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -124,12 +124,22 @@ set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "1
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
 
 # Show the ~/Library folder
-chflags nohidden ~/Library
-logger -t chezmoi-macos-defaults "Unhid ~/Library"
+if ls -ldO "$HOME/Library" | grep -q hidden; then
+  if chflags nohidden "$HOME/Library"; then
+    logger -t chezmoi-macos-defaults "Unhid ~/Library"
+  else
+    logger -t chezmoi-macos-defaults "Failed to unhide ~/Library"
+  fi
+fi
 
 # Show the /Volumes folder
-sudo chflags nohidden /Volumes
-logger -t chezmoi-macos-defaults "Unhid /Volumes"
+if ls -ldO /Volumes | grep -q hidden; then
+  if sudo chflags nohidden /Volumes; then
+    logger -t chezmoi-macos-defaults "Unhid /Volumes"
+  else
+    logger -t chezmoi-macos-defaults "Failed to unhide /Volumes"
+  fi
+fi
 
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -101,10 +101,14 @@ set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer"
 set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 
 # Show the ~/Library folder
-chflags nohidden ~/Library
+if ls -ldO "$HOME/Library" | grep -q hidden; then
+  chflags nohidden "$HOME/Library" || true
+fi
 
 # Show the /Volumes folder
-sudo chflags nohidden /Volumes
+if ls -ldO /Volumes | grep -q hidden; then
+  sudo chflags nohidden /Volumes || true
+fi
 
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -100,5 +100,11 @@ set_finder_pref "DesktopViewSettings:IconViewSettings:gridSpacing" "integer" "10
 set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 
+# Show the ~/Library folder
+chflags nohidden ~/Library
+
+# Show the /Volumes folder
+sudo chflags nohidden /Volumes
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
This PR implements the user's request to unhide the `~/Library` and `/Volumes` folders on macOS, mirroring functionality found in `jessfraz/dotfiles`.

**Changes:**
- Modified `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` to run `chflags nohidden ~/Library` and `sudo chflags nohidden /Volumes`, along with appropriate `logger` messages.
- Kept the standalone `dot_local/bin/macos_defaults.sh` script synchronized with the same commands (omitting the `logger` statements as per guidelines).
- Ensured these commands run *before* the final `killall` step so changes are registered immediately.

**Files Edited:**
- `.chezmoiscripts/run_once_macos-defaults.sh.tmpl`
- `dot_local/bin/macos_defaults.sh`

---
*PR created automatically by Jules for task [11904097378633662411](https://jules.google.com/task/11904097378633662411) started by @arran4*