### PR TITLE
feat: add macOS defaults for Dock and Mission Control animations

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -141,6 +141,14 @@ if ls -ldO /Volumes | grep -q hidden; then
   fi
 fi
 
+# Don't animate opening applications from the Dock
+defaults write com.apple.dock launchanim -bool false
+logger -t chezmoi-macos-defaults "Updated com.apple.dock launchanim to false"
+
+# Speed up Mission Control animations
+defaults write com.apple.dock expose-animation-duration -float 0.1
+logger -t chezmoi-macos-defaults "Updated com.apple.dock expose-animation-duration to 0.1"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -110,5 +110,11 @@ if ls -ldO /Volumes | grep -q hidden; then
   sudo chflags nohidden /Volumes || true
 fi
 
+# Don't animate opening applications from the Dock
+defaults write com.apple.dock launchanim -bool false
+
+# Speed up Mission Control animations
+defaults write com.apple.dock expose-animation-duration -float 0.1
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
Adds macOS default commands to disable the Dock launch animation and decrease the Mission Control expose animation duration, based on Jess Frazelle's dotfiles. These have been placed in both the `chezmoiscripts` run-once template and the `bin/macos_defaults.sh` helper script.

---
*PR created automatically by Jules for task [13547643461874834237](https://jules.google.com/task/13547643461874834237) started by @arran4*