### PR TITLE
feat: remove macOS Dock auto-hide delay and animation

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -15,7 +15,13 @@ logger -t chezmoi-macos-defaults "Updated com.apple.screencapture location to ${
 defaults write com.apple.screencapture type -string "png"
 logger -t chezmoi-macos-defaults "Updated com.apple.screencapture type to png"
 
-# Dock: auto hide and disable recent apps
+# Dock: auto hide, remove delay and animation, and disable recent apps
+defaults write com.apple.dock autohide-delay -float 0
+logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide-delay to 0"
+
+defaults write com.apple.dock autohide-time-modifier -float 0
+logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide-time-modifier to 0"
+
 defaults write com.apple.dock autohide -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide to true"
 

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -18,7 +18,9 @@ case "$answer" in
     ;;
 esac
 
-# Dock: auto hide and disable recent apps
+# Dock: auto hide, remove delay and animation, and disable recent apps
+defaults write com.apple.dock autohide-delay -float 0
+defaults write com.apple.dock autohide-time-modifier -float 0
 defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock show-recents -bool false
 


### PR DESCRIPTION
This commit adds settings to remove the macOS dock auto-hide delay and animation modifier.

Changes made:
- Added `defaults write com.apple.dock autohide-delay -float 0`
- Added `defaults write com.apple.dock autohide-time-modifier -float 0`
- Updated both `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` (with logging) and `dot_local/bin/macos_defaults.sh` (without logging) to keep them in sync.

---
*PR created automatically by Jules for task [9321047805782858071](https://jules.google.com/task/9321047805782858071) started by @arran4*