### PR TITLE
feat(macos): always show scrollbars

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -155,6 +155,11 @@ logger -t chezmoi-macos-defaults "Updated com.apple.dock launchanim to false"
 defaults write com.apple.dock expose-animation-duration -float 0.1
 logger -t chezmoi-macos-defaults "Updated com.apple.dock expose-animation-duration to 0.1"
 
+# Always show scrollbars
+# Possible values: `WhenScrolling`, `Automatic` and `Always`
+defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowScrollBars to Always"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -118,5 +118,9 @@ defaults write com.apple.dock launchanim -bool false
 # Speed up Mission Control animations
 defaults write com.apple.dock expose-animation-duration -float 0.1
 
+# Always show scrollbars
+# Possible values: `WhenScrolling`, `Automatic` and `Always`
+defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
Adds setting to consistently show scrollbars on macOS by default in both automated and standalone dotfiles scripts.

---
*PR created automatically by Jules for task [2313494164136065555](https://jules.google.com/task/2313494164136065555) started by @arran4*