### PR TITLE
feat: disable macos boot sound effects

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -160,6 +160,10 @@ logger -t chezmoi-macos-defaults "Updated com.apple.dock expose-animation-durati
 defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
 logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowScrollBars to Always"
 
+# Disable the sound effects on boot
+sudo nvram SystemAudioVolume=" " || true
+logger -t chezmoi-macos-defaults "Disabled sound effects on boot"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -161,8 +161,14 @@ defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
 logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowScrollBars to Always"
 
 # Disable the sound effects on boot
-sudo nvram SystemAudioVolume=" " || true
-logger -t chezmoi-macos-defaults "Disabled sound effects on boot"
+macos_major_version=$(sw_vers -productVersion | cut -d. -f1)
+if [ "$macos_major_version" -ge 11 ]; then
+  sudo nvram StartupMute=%01 || true
+  logger -t chezmoi-macos-defaults "Disabled sound effects on boot (StartupMute)"
+else
+  sudo nvram SystemAudioVolume=" " || true
+  logger -t chezmoi-macos-defaults "Disabled sound effects on boot (SystemAudioVolume)"
+fi
 
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -122,5 +122,8 @@ defaults write com.apple.dock expose-animation-duration -float 0.1
 # Possible values: `WhenScrolling`, `Automatic` and `Always`
 defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
 
+# Disable the sound effects on boot
+sudo nvram SystemAudioVolume=" " || true
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -123,7 +123,12 @@ defaults write com.apple.dock expose-animation-duration -float 0.1
 defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
 
 # Disable the sound effects on boot
-sudo nvram SystemAudioVolume=" " || true
+macos_major_version=$(sw_vers -productVersion | cut -d. -f1)
+if [ "$macos_major_version" -ge 11 ]; then
+  sudo nvram StartupMute=%01 || true
+else
+  sudo nvram SystemAudioVolume=" " || true
+fi
 
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
Added the command to disable the macOS boot sound effect (`sudo nvram SystemAudioVolume=" "`) in `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` and `dot_local/bin/macos_defaults.sh`. Added `|| true` to prevent the scripts from failing if the user lacks `sudo` privileges or the NVRAM modification fails. Including logging for the chezmoi script.

---
*PR created automatically by Jules for task [15791755287021114322](https://jules.google.com/task/15791755287021114322) started by @arran4*