### PR TITLE
Add macOS defaults for focus ring and scrolling

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -170,6 +170,18 @@ else
   logger -t chezmoi-macos-defaults "Disabled sound effects on boot (SystemAudioVolume)"
 fi
 
+# Disable the over-the-top focus ring animation
+defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSUseAnimatedFocusRing to false"
+
+# Disable smooth scrolling
+# (Uncomment if you’re on an older Mac that messes up the animation)
+#defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false
+
+# Increase window resize speed for Cocoa applications
+defaults write NSGlobalDomain NSWindowResizeTime -float 0.001
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSWindowResizeTime to 0.001"
+
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true
 logger -t chezmoi-macos-defaults "Restarted Dock, Finder and SystemUIServer to apply changes"

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -170,15 +170,15 @@ else
   logger -t chezmoi-macos-defaults "Disabled sound effects on boot (SystemAudioVolume)"
 fi
 
-# Disable the over-the-top focus ring animation
+# Disable the over-the-top focus ring animation (requires logout/restart to apply system-wide)
 defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
 logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSUseAnimatedFocusRing to false"
 
 # Disable smooth scrolling
-# (Uncomment if you’re on an older Mac that messes up the animation)
+# (Uncomment if you're on an older Mac that messes up the animation)
 #defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false
 
-# Increase window resize speed for Cocoa applications
+# Increase window resize speed for Cocoa applications (requires logout/restart to apply system-wide)
 defaults write NSGlobalDomain NSWindowResizeTime -float 0.001
 logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSWindowResizeTime to 0.001"
 

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -130,14 +130,14 @@ else
   sudo nvram SystemAudioVolume=" " || true
 fi
 
-# Disable the over-the-top focus ring animation
+# Disable the over-the-top focus ring animation (requires logout/restart to apply system-wide)
 defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
 
 # Disable smooth scrolling
-# (Uncomment if you’re on an older Mac that messes up the animation)
+# (Uncomment if you're on an older Mac that messes up the animation)
 #defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false
 
-# Increase window resize speed for Cocoa applications
+# Increase window resize speed for Cocoa applications (requires logout/restart to apply system-wide)
 defaults write NSGlobalDomain NSWindowResizeTime -float 0.001
 
 # Restart affected services

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -130,5 +130,15 @@ else
   sudo nvram SystemAudioVolume=" " || true
 fi
 
+# Disable the over-the-top focus ring animation
+defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
+
+# Disable smooth scrolling
+# (Uncomment if you’re on an older Mac that messes up the animation)
+#defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false
+
+# Increase window resize speed for Cocoa applications
+defaults write NSGlobalDomain NSWindowResizeTime -float 0.001
+
 # Restart affected services
 killall Dock Finder SystemUIServer >/dev/null 2>&1 || true


### PR DESCRIPTION
Added macOS default commands to disable focus ring animation, comment for smooth scrolling, and increase window resize speed based on user request.

---
*PR created automatically by Jules for task [5773033735420095495](https://jules.google.com/task/5773033735420095495) started by @arran4*