### PR TITLE
feat: add GitHub and Gist URL shortcuts to Git config

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -210,6 +210,27 @@
 [interactive "delta"]
   diffFilter = delta --color-only
 
+[url "git@github.com:github"]
+  insteadOf = "https://github.com/github"
+  insteadOf = "github:github"
+  insteadOf = "git://github.com/github"
+
+[url "git@github.com:"]
+  pushInsteadOf = "https://github.com/"
+  pushInsteadOf = "github:"
+  pushInsteadOf = "git://github.com/"
+
+[url "git://github.com/"]
+  insteadOf = "github:"
+
+[url "git@gist.github.com:"]
+  insteadOf = "gst:"
+  pushInsteadOf = "gist:"
+  pushInsteadOf = "git://gist.github.com/"
+
+[url "git://gist.github.com/"]
+  insteadOf = "gist:"
+
 [http]
   cookiefile = ~/.cache/git/cookies
 


### PR DESCRIPTION
Added `insteadOf` and `pushInsteadOf` configurations to `dot_gitconfig.tmpl` to enable convenient URL shortcuts like `github:` and `gist:`.

---
*PR created automatically by Jules for task [12759422058947669637](https://jules.google.com/task/12759422058947669637) started by @arran4*