### PR TITLE
docs(macos): expand acronyms in defaults comments

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -29,7 +29,7 @@ defaults write com.apple.dock show-recents -bool false
 logger -t chezmoi-macos-defaults "Updated com.apple.dock show-recents to false"
 
 # Use list view in all Finder windows by default
-# Four-letter codes for the other view modes: `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
+# Four-letter codes for the view modes: `Nlsv` (List View), `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder FXPreferredViewStyle to Nlsv"
 
@@ -67,6 +67,7 @@ defaults write com.apple.finder _FXSortFoldersFirstOnDesktop -bool true
 logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirstOnDesktop to true"
 
 # When performing a search, search the current folder by default
+# Search scope codes: `SCcf` (Search Current Folder), `SCsp` (Search Previous Scope), `SCev` (Search this Mac)
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder FXDefaultSearchScope to SCcf"
 
@@ -75,6 +76,7 @@ defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 logger -t chezmoi-macos-defaults "Updated com.apple.finder FXEnableExtensionChangeWarning to false"
 
 # Set Documents as the default location for new Finder windows
+# Location codes: `PfLo` (Custom Location, requires NewWindowTargetPath), `PfDe` (Desktop), `PfHm` (Home), `PfDo` (Documents)
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
 logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to PfLo"
 

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -25,7 +25,7 @@ defaults write com.apple.dock autohide -bool true
 defaults write com.apple.dock show-recents -bool false
 
 # Use list view in all Finder windows by default
-# Four-letter codes for the other view modes: `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
+# Four-letter codes for the view modes: `Nlsv` (List View), `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 
 # Finder: show path bar and status bar
@@ -50,12 +50,14 @@ defaults write com.apple.finder _FXSortFoldersFirst -bool true
 defaults write com.apple.finder _FXSortFoldersFirstOnDesktop -bool true
 
 # When performing a search, search the current folder by default
+# Search scope codes: `SCcf` (Search Current Folder), `SCsp` (Search Previous Scope), `SCev` (Search this Mac)
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
 
 # Disable the warning when changing a file extension
 defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 
 # Set Documents as the default location for new Finder windows
+# Location codes: `PfLo` (Custom Location, requires NewWindowTargetPath), `PfDe` (Desktop), `PfHm` (Home), `PfDo` (Documents)
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
 defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"
 


### PR DESCRIPTION
Added explicit explanations for the cryptic four-letter codes used in macOS `defaults write` commands for Finder preferences, specifically for `FXPreferredViewStyle`, `FXDefaultSearchScope`, and `NewWindowTarget`. These comments now detail both the selected code and the available alternative options, improving maintainability in both the local executable script and the chezmoiscript template.

---
*PR created automatically by Jules for task [11876702668201073947](https://jules.google.com/task/11876702668201073947) started by @arran4*