### PR TITLE
Fix SC2010 in macos_defaults.sh

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -132,7 +132,7 @@ set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "1
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
 
 # Show the ~/Library folder
-if [[ "$(ls -ldO "$HOME/Library")" == *hidden* ]]; then
+if [[ "$(stat -f "%Sf" "$HOME/Library")" == *hidden* ]]; then
   if chflags nohidden "$HOME/Library"; then
     logger -t chezmoi-macos-defaults "Unhid ~/Library"
   else
@@ -141,7 +141,7 @@ if [[ "$(ls -ldO "$HOME/Library")" == *hidden* ]]; then
 fi
 
 # Show the /Volumes folder
-if [[ "$(ls -ldO /Volumes)" == *hidden* ]]; then
+if [[ "$(stat -f "%Sf" /Volumes)" == *hidden* ]]; then
   if sudo chflags nohidden /Volumes; then
     logger -t chezmoi-macos-defaults "Unhid /Volumes"
   else

--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -132,7 +132,7 @@ set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "1
 logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
 
 # Show the ~/Library folder
-if ls -ldO "$HOME/Library" | grep -q hidden; then
+if [[ "$(ls -ldO "$HOME/Library")" == *hidden* ]]; then
   if chflags nohidden "$HOME/Library"; then
     logger -t chezmoi-macos-defaults "Unhid ~/Library"
   else
@@ -141,7 +141,7 @@ if ls -ldO "$HOME/Library" | grep -q hidden; then
 fi
 
 # Show the /Volumes folder
-if ls -ldO /Volumes | grep -q hidden; then
+if [[ "$(ls -ldO /Volumes)" == *hidden* ]]; then
   if sudo chflags nohidden /Volumes; then
     logger -t chezmoi-macos-defaults "Unhid /Volumes"
   else

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -105,12 +105,12 @@ set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer"
 set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 
 # Show the ~/Library folder
-if [[ "$(ls -ldO "$HOME/Library")" == *hidden* ]]; then
+if [[ "$(stat -f "%Sf" "$HOME/Library")" == *hidden* ]]; then
   chflags nohidden "$HOME/Library" || true
 fi
 
 # Show the /Volumes folder
-if [[ "$(ls -ldO /Volumes)" == *hidden* ]]; then
+if [[ "$(stat -f "%Sf" /Volumes)" == *hidden* ]]; then
   sudo chflags nohidden /Volumes || true
 fi
 

--- a/dot_local/bin/macos_defaults.sh
+++ b/dot_local/bin/macos_defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Apply macOS defaults for Dock, Finder and screenshots
 
@@ -105,12 +105,12 @@ set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer"
 set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 
 # Show the ~/Library folder
-if ls -ldO "$HOME/Library" | grep -q hidden; then
+if [[ "$(ls -ldO "$HOME/Library")" == *hidden* ]]; then
   chflags nohidden "$HOME/Library" || true
 fi
 
 # Show the /Volumes folder
-if ls -ldO /Volumes | grep -q hidden; then
+if [[ "$(ls -ldO /Volumes)" == *hidden* ]]; then
   sudo chflags nohidden /Volumes || true
 fi
 


### PR DESCRIPTION
Fixes Shellcheck warning SC2010 ("Don't use ls | grep") in macOS defaults scripts.

---
*PR created automatically by Jules for task [6731453502620342438](https://jules.google.com/task/6731453502620342438) started by @arran4*