### PR TITLE
Log previous values in macOS defaults script

### DIFF
--- a/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
+++ b/.chezmoiscripts/run_once_macos-defaults.sh.tmpl
@@ -8,95 +8,120 @@ mkdir -p "${HOME}/Pictures/Screenshots"
 logger -t chezmoi-macos-defaults "Created/verified Screenshots directory at ${HOME}/Pictures/Screenshots"
 
 # Save screenshots to the Pictures/Screenshots directory
+prevvalue=$(defaults read com.apple.screencapture "location" 2>/dev/null || echo "not set")
 defaults write com.apple.screencapture location -string "${HOME}/Pictures/Screenshots"
-logger -t chezmoi-macos-defaults "Updated com.apple.screencapture location to ${HOME}/Pictures/Screenshots"
+logger -t chezmoi-macos-defaults "Updated com.apple.screencapture location to ${HOME}/Pictures/Screenshots. From $prevvalue"
 
 # Save screenshots in PNG format (other options: BMP, GIF, JPG, PDF, TIFF)
+prevvalue=$(defaults read com.apple.screencapture "type" 2>/dev/null || echo "not set")
 defaults write com.apple.screencapture type -string "png"
-logger -t chezmoi-macos-defaults "Updated com.apple.screencapture type to png"
+logger -t chezmoi-macos-defaults "Updated com.apple.screencapture type to png. From $prevvalue"
 
 # Dock: auto hide, remove delay and animation, and disable recent apps
+prevvalue=$(defaults read com.apple.dock "autohide-delay" 2>/dev/null || echo "not set")
 defaults write com.apple.dock autohide-delay -float 0
-logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide-delay to 0"
+logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide-delay to 0. From $prevvalue"
 
+prevvalue=$(defaults read com.apple.dock "autohide-time-modifier" 2>/dev/null || echo "not set")
 defaults write com.apple.dock autohide-time-modifier -float 0
-logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide-time-modifier to 0"
+logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide-time-modifier to 0. From $prevvalue"
 
+prevvalue=$(defaults read com.apple.dock "autohide" 2>/dev/null || echo "not set")
 defaults write com.apple.dock autohide -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.dock autohide to true. From $prevvalue"
 
+prevvalue=$(defaults read com.apple.dock "show-recents" 2>/dev/null || echo "not set")
 defaults write com.apple.dock show-recents -bool false
-logger -t chezmoi-macos-defaults "Updated com.apple.dock show-recents to false"
+logger -t chezmoi-macos-defaults "Updated com.apple.dock show-recents to false. From $prevvalue"
 
 # Use list view in all Finder windows by default
 # Four-letter codes for the view modes: `Nlsv` (List View), `icnv` (Icon View), `clmv` (Column View), `glyv` (Gallery View)
+prevvalue=$(defaults read com.apple.finder "FXPreferredViewStyle" 2>/dev/null || echo "not set")
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder FXPreferredViewStyle to Nlsv"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder FXPreferredViewStyle to Nlsv. From $prevvalue"
 
 # Finder: show path bar and status bar
+prevvalue=$(defaults read com.apple.finder "ShowPathbar" 2>/dev/null || echo "not set")
 defaults write com.apple.finder ShowPathbar -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder ShowPathbar to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder ShowPathbar to true. From $prevvalue"
 
+prevvalue=$(defaults read com.apple.finder "ShowStatusBar" 2>/dev/null || echo "not set")
 defaults write com.apple.finder ShowStatusBar -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder ShowStatusBar to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder ShowStatusBar to true. From $prevvalue"
 
 # Finder: allow quitting via ⌘ + Q; doing so will also hide desktop icons
+prevvalue=$(defaults read com.apple.finder "QuitMenuItem" 2>/dev/null || echo "not set")
 defaults write com.apple.finder QuitMenuItem -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder QuitMenuItem to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder QuitMenuItem to true. From $prevvalue"
 
 # Finder: disable window animations and Get Info animations
+prevvalue=$(defaults read com.apple.finder "DisableAllAnimations" 2>/dev/null || echo "not set")
 defaults write com.apple.finder DisableAllAnimations -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder DisableAllAnimations to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder DisableAllAnimations to true. From $prevvalue"
 
 # Finder: show hidden files by default
+prevvalue=$(defaults read com.apple.finder "AppleShowAllFiles" 2>/dev/null || echo "not set")
 defaults write com.apple.finder AppleShowAllFiles -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder AppleShowAllFiles to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder AppleShowAllFiles to true. From $prevvalue"
 
 # Finder: show all filename extensions
+prevvalue=$(defaults read NSGlobalDomain "AppleShowAllExtensions" 2>/dev/null || echo "not set")
 defaults write NSGlobalDomain AppleShowAllExtensions -bool true
-logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowAllExtensions to true"
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowAllExtensions to true. From $prevvalue"
 
 # Display full POSIX path as Finder window title
+prevvalue=$(defaults read com.apple.finder "_FXShowPosixPathInTitle" 2>/dev/null || echo "not set")
 defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXShowPosixPathInTitle to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXShowPosixPathInTitle to true. From $prevvalue"
 
 # Keep folders on top when sorting by name
+prevvalue=$(defaults read com.apple.finder "_FXSortFoldersFirst" 2>/dev/null || echo "not set")
 defaults write com.apple.finder _FXSortFoldersFirst -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirst to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirst to true. From $prevvalue"
+prevvalue=$(defaults read com.apple.finder "_FXSortFoldersFirstOnDesktop" 2>/dev/null || echo "not set")
 defaults write com.apple.finder _FXSortFoldersFirstOnDesktop -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirstOnDesktop to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder _FXSortFoldersFirstOnDesktop to true. From $prevvalue"
 
 # When performing a search, search the current folder by default
 # Search scope codes: `SCcf` (Search Current Folder), `SCsp` (Search Previous Scope), `SCev` (Search this Mac)
+prevvalue=$(defaults read com.apple.finder "FXDefaultSearchScope" 2>/dev/null || echo "not set")
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder FXDefaultSearchScope to SCcf"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder FXDefaultSearchScope to SCcf. From $prevvalue"
 
 # Disable the warning when changing a file extension
+prevvalue=$(defaults read com.apple.finder "FXEnableExtensionChangeWarning" 2>/dev/null || echo "not set")
 defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
-logger -t chezmoi-macos-defaults "Updated com.apple.finder FXEnableExtensionChangeWarning to false"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder FXEnableExtensionChangeWarning to false. From $prevvalue"
 
 # Set Documents as the default location for new Finder windows
 # Location codes: `PfLo` (Custom Location, requires NewWindowTargetPath), `PfDe` (Desktop), `PfHm` (Home), `PfDo` (Documents)
+prevvalue=$(defaults read com.apple.finder "NewWindowTarget" 2>/dev/null || echo "not set")
 defaults write com.apple.finder NewWindowTarget -string "PfLo"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to PfLo"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTarget to PfLo. From $prevvalue"
 
+prevvalue=$(defaults read com.apple.finder "NewWindowTargetPath" 2>/dev/null || echo "not set")
 defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Documents/"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTargetPath to file://${HOME}/Documents/"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder NewWindowTargetPath to file://${HOME}/Documents/. From $prevvalue"
 
 # Avoid creating .DS_Store files on network or USB volumes
+prevvalue=$(defaults read com.apple.desktopservices "DSDontWriteNetworkStores" 2>/dev/null || echo "not set")
 defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteNetworkStores to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteNetworkStores to true. From $prevvalue"
 
+prevvalue=$(defaults read com.apple.desktopservices "DSDontWriteUSBStores" 2>/dev/null || echo "not set")
 defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteUSBStores to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.desktopservices DSDontWriteUSBStores to true. From $prevvalue"
 
 # Automatically open a new Finder window when a volume is mounted
+prevvalue=$(defaults read com.apple.frameworks.diskimages "auto-open-ro-root" 2>/dev/null || echo "not set")
 defaults write com.apple.frameworks.diskimages auto-open-ro-root -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-open-ro-root to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-open-ro-root to true. From $prevvalue"
+prevvalue=$(defaults read com.apple.frameworks.diskimages "auto-open-rw-root" 2>/dev/null || echo "not set")
 defaults write com.apple.frameworks.diskimages auto-open-rw-root -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-open-rw-root to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.frameworks.diskimages auto-open-rw-root to true. From $prevvalue"
+prevvalue=$(defaults read com.apple.finder "OpenWindowForNewRemovableDisk" 2>/dev/null || echo "not set")
 defaults write com.apple.finder OpenWindowForNewRemovableDisk -bool true
-logger -t chezmoi-macos-defaults "Updated com.apple.finder OpenWindowForNewRemovableDisk to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder OpenWindowForNewRemovableDisk to true. From $prevvalue"
 
 # Ensure parent dictionaries exist in com.apple.finder.plist
 for domain in DesktopViewSettings FK_StandardViewSettings StandardViewSettings; do
@@ -110,26 +135,30 @@ set_finder_pref() {
 }
 
 # Show item info near icons on the desktop and in other icon views
+prevvalue=$(/usr/libexec/PlistBuddy -c "Print :DesktopViewSettings:IconViewSettings:showItemInfo" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null || echo "not set")
 set_finder_pref "DesktopViewSettings:IconViewSettings:showItemInfo" "bool" "true"
 set_finder_pref "FK_StandardViewSettings:IconViewSettings:showItemInfo" "bool" "true"
 set_finder_pref "StandardViewSettings:IconViewSettings:showItemInfo" "bool" "true"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings showItemInfo to true"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings showItemInfo to true. From $prevvalue"
 
 # Show item info to the right of the icons on the desktop
+prevvalue=$(/usr/libexec/PlistBuddy -c "Print :DesktopViewSettings:IconViewSettings:labelOnBottom" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null || echo "not set")
 set_finder_pref "DesktopViewSettings:IconViewSettings:labelOnBottom" "bool" "false"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist labelOnBottom to false"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist labelOnBottom to false. From $prevvalue"
 
 # Enable snap-to-grid for icons on the desktop and in other icon views
+prevvalue=$(/usr/libexec/PlistBuddy -c "Print :DesktopViewSettings:IconViewSettings:arrangeBy" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null || echo "not set")
 set_finder_pref "DesktopViewSettings:IconViewSettings:arrangeBy" "string" "grid"
 set_finder_pref "FK_StandardViewSettings:IconViewSettings:arrangeBy" "string" "grid"
 set_finder_pref "StandardViewSettings:IconViewSettings:arrangeBy" "string" "grid"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings arrangeBy to grid"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings arrangeBy to grid. From $prevvalue"
 
 # Increase grid spacing for icons on the desktop and in other icon views
+prevvalue=$(/usr/libexec/PlistBuddy -c "Print :DesktopViewSettings:IconViewSettings:gridSpacing" "$HOME/Library/Preferences/com.apple.finder.plist" 2>/dev/null || echo "not set")
 set_finder_pref "DesktopViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 set_finder_pref "FK_StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
 set_finder_pref "StandardViewSettings:IconViewSettings:gridSpacing" "integer" "100"
-logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100"
+logger -t chezmoi-macos-defaults "Updated com.apple.finder.plist icon view settings gridSpacing to 100. From $prevvalue"
 
 # Show the ~/Library folder
 if [[ "$(stat -f "%Sf" "$HOME/Library")" == *hidden* ]]; then
@@ -150,17 +179,20 @@ if [[ "$(stat -f "%Sf" /Volumes)" == *hidden* ]]; then
 fi
 
 # Don't animate opening applications from the Dock
+prevvalue=$(defaults read com.apple.dock "launchanim" 2>/dev/null || echo "not set")
 defaults write com.apple.dock launchanim -bool false
-logger -t chezmoi-macos-defaults "Updated com.apple.dock launchanim to false"
+logger -t chezmoi-macos-defaults "Updated com.apple.dock launchanim to false. From $prevvalue"
 
 # Speed up Mission Control animations
+prevvalue=$(defaults read com.apple.dock "expose-animation-duration" 2>/dev/null || echo "not set")
 defaults write com.apple.dock expose-animation-duration -float 0.1
-logger -t chezmoi-macos-defaults "Updated com.apple.dock expose-animation-duration to 0.1"
+logger -t chezmoi-macos-defaults "Updated com.apple.dock expose-animation-duration to 0.1. From $prevvalue"
 
 # Always show scrollbars
 # Possible values: `WhenScrolling`, `Automatic` and `Always`
+prevvalue=$(defaults read NSGlobalDomain "AppleShowScrollBars" 2>/dev/null || echo "not set")
 defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
-logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowScrollBars to Always"
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain AppleShowScrollBars to Always. From $prevvalue"
 
 # Disable the sound effects on boot
 macos_major_version=$(sw_vers -productVersion | cut -d. -f1)
@@ -173,16 +205,18 @@ else
 fi
 
 # Disable the over-the-top focus ring animation (requires logout/restart to apply system-wide)
+prevvalue=$(defaults read NSGlobalDomain "NSUseAnimatedFocusRing" 2>/dev/null || echo "not set")
 defaults write NSGlobalDomain NSUseAnimatedFocusRing -bool false
-logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSUseAnimatedFocusRing to false"
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSUseAnimatedFocusRing to false. From $prevvalue"
 
 # Disable smooth scrolling
 # (Uncomment if you're on an older Mac that messes up the animation)
 #defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false
 
 # Increase window resize speed for Cocoa applications (requires logout/restart to apply system-wide)
+prevvalue=$(defaults read NSGlobalDomain "NSWindowResizeTime" 2>/dev/null || echo "not set")
 defaults write NSGlobalDomain NSWindowResizeTime -float 0.001
-logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSWindowResizeTime to 0.001"
+logger -t chezmoi-macos-defaults "Updated NSGlobalDomain NSWindowResizeTime to 0.001. From $prevvalue"
 
 # Ensure the changes take effect
 killall Dock Finder SystemUIServer 2>/dev/null || true


### PR DESCRIPTION
This modifies `.chezmoiscripts/run_once_macos-defaults.sh.tmpl` to read the previous default value for macOS properties before overriding them, appending the previous value (`. From $prevvalue`) to the corresponding `logger` syslog statement for better tracking and auditing. PlistBuddy properties are also updated accordingly.

---
*PR created automatically by Jules for task [12300508666459938272](https://jules.google.com/task/12300508666459938272) started by @arran4*