### PR TITLE
Migrate system applications to flatpak

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -56,7 +56,6 @@
         {{- $paths = append $paths (joinPath .chezmoi.homeDir "/.local/share/flatpak/exports/bin") -}}
         {{- $paths = append $paths "/var/lib/flatpak/exports/bin" -}}
         {{- $paths = append $paths "/usr/games/bin" -}}
-        {{- $paths = append $paths "/opt/Bitwarden" -}}
         {{- $paths = append $paths "/opt/bin" -}}
         {{- $terminfosearch = list "/usr/share/terminfo" "/usr/lib/share/terminfo" "/usr/share/lib/terminfo" -}}
         {{- $termfallback = list "rxvt" "xterm" "linux" "vt100" -}}
@@ -341,10 +340,7 @@
   {{- $nmAppletLocation = lookPath "nm-applet" -}}
 {{- end -}}
 
-{{- $anytypeLocation := findExecutable "Anytype.AppImage" $paths -}}
-{{- if eq $anytypeLocation "" -}}
-  {{- $anytypeLocation = lookPath "Anytype.AppImage" -}}
-{{- end -}}
+{{- $anytypeLocation := "flatpak run io.anytype.anytype" -}}
 {{- $wofiLocation := findExecutable "wofi" $paths -}}
 {{- if eq $wofiLocation "" -}}
   {{- $wofiLocation = lookPath "wofi" -}}
@@ -592,11 +588,19 @@
         {{- writeToStdout "Can't find nm-applet \n" -}}
 {{- end -}}
 
-{{- if not (stat $anytypeLocation ) -}}
-        {{- writeToStdout "Can't find Anytype.AppImage \n" -}}
+{{- $flatpakLocation := lookPath "flatpak" -}}
+{{- if eq $flatpakLocation "" -}}
+        {{- writeToStdout "Can't find flatpak. Missing flatpak apps, run: flatpak install -y flathub app.authpass.AuthPass com.bitwarden.desktop com.dropbox.Client com.spotify.Client com.valvesoftware.Steam im.fluffychat.Fluffychat im.nheko.Nheko im.riot.Riot io.anytype.anytype io.ente.auth io.github.martinrotter.rssguard net.werwolv.ImHex org.kde.drawy org.signal.Signal\n" -}}
 {{- else -}}
-        {{- writeToStdout (printf "Anytype installed at %s\n" $anytypeLocation) -}}
+        {{- $installedFlatpaks := output $flatpakLocation "list" "--app" "--columns=application" -}}
+        {{- $flatpakApps := list "app.authpass.AuthPass" "com.bitwarden.desktop" "com.dropbox.Client" "com.spotify.Client" "com.valvesoftware.Steam" "im.fluffychat.Fluffychat" "im.nheko.Nheko" "im.riot.Riot" "io.anytype.anytype" "io.ente.auth" "io.github.martinrotter.rssguard" "net.werwolv.ImHex" "org.kde.drawy" "org.signal.Signal" -}}
+        {{- range $app := $flatpakApps -}}
+                {{- if not (contains $app $installedFlatpaks) -}}
+                        {{- writeToStdout (printf "Flatpak app %s is not installed. Run: flatpak install -y flathub %s\n" $app $app) -}}
+                {{- end -}}
+        {{- end -}}
 {{- end -}}
+
 [git]
     autoCommit = {{ $autoGit }}
     autoPush = {{ $autoGit }}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -592,10 +592,10 @@
 {{- if eq $flatpakLocation "" -}}
         {{- writeToStdout "Can't find flatpak. Missing flatpak apps, run: flatpak install -y flathub app.authpass.AuthPass com.bitwarden.desktop com.dropbox.Client com.spotify.Client com.valvesoftware.Steam im.fluffychat.Fluffychat im.nheko.Nheko im.riot.Riot io.anytype.anytype io.ente.auth io.github.martinrotter.rssguard net.werwolv.ImHex org.kde.drawy org.signal.Signal\n" -}}
 {{- else -}}
-        {{- $installedFlatpaks := output $flatpakLocation "list" "--app" "--columns=application" -}}
+        {{- $installedFlatpaks := output $flatpakLocation "list" "--app" "--columns=application" | splitList "\n" -}}
         {{- $flatpakApps := list "app.authpass.AuthPass" "com.bitwarden.desktop" "com.dropbox.Client" "com.spotify.Client" "com.valvesoftware.Steam" "im.fluffychat.Fluffychat" "im.nheko.Nheko" "im.riot.Riot" "io.anytype.anytype" "io.ente.auth" "io.github.martinrotter.rssguard" "net.werwolv.ImHex" "org.kde.drawy" "org.signal.Signal" -}}
         {{- range $app := $flatpakApps -}}
-                {{- if not (contains $app $installedFlatpaks) -}}
+                {{- if not (has $app $installedFlatpaks) -}}
                         {{- writeToStdout (printf "Flatpak app %s is not installed. Run: flatpak install -y flathub %s\n" $app $app) -}}
                 {{- end -}}
         {{- end -}}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ Highlights include:
 
 Feel free to copy individual pieces or adapt the whole setup to suit your needs.
 
+## Flatpak Apps
+
+I use the following flatpak applications in this environment:
+- AuthPass (`app.authpass.AuthPass`)
+- Bitwarden (`com.bitwarden.desktop`)
+- Dropbox (`com.dropbox.Client`)
+- Spotify (`com.spotify.Client`)
+- Steam (`com.valvesoftware.Steam`)
+- Fluffychat (`im.fluffychat.Fluffychat`)
+- Nheko (`im.nheko.Nheko`)
+- Element/Riot (`im.riot.Riot`)
+- Anytype (`io.anytype.anytype`)
+- Ente Auth (`io.ente.auth`)
+- RSS Guard (`io.github.martinrotter.rssguard`)
+- ImHex (`net.werwolv.ImHex`)
+- Drawy (`org.kde.drawy`)
+- Signal Desktop (`org.signal.Signal`)
+
+You can install them automatically with this one-liner:
+```sh
+flatpak install -y flathub app.authpass.AuthPass com.bitwarden.desktop com.dropbox.Client com.spotify.Client com.valvesoftware.Steam im.fluffychat.Fluffychat im.nheko.Nheko im.riot.Riot io.anytype.anytype io.ente.auth io.github.martinrotter.rssguard net.werwolv.ImHex org.kde.drawy org.signal.Signal
+```
+
 ### Try it out
 
 1. Clone the repository and run `./install`.


### PR DESCRIPTION
- Updates `.chezmoi.toml.tmpl` to switch away from `Anytype.AppImage` and system `/opt/Bitwarden` paths.
- Implements a flatpak check loop in `.chezmoi.toml.tmpl` to verify the presence of user-requested applications.
- Instructs the user to run `flatpak install -y flathub ...` for any missing applications.
- Updates `README.md` to list the currently used flatpak applications and provides an auto-accepting one-liner for easy installation.

---
*PR created automatically by Jules for task [1392137003924093610](https://jules.google.com/task/1392137003924093610) started by @arran4*