### PR TITLE
feat: Add golangci-lint check and update README

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -242,6 +242,22 @@
 {{- if eq $golangciLintLocation "" -}}
   {{- $golangciLintLocation = lookPath "golangci-lint" -}}
 {{- end -}}
+{{- if and (eq $golangciLintLocation "") (ne $goLocation "") -}}
+  {{- $goBin := trim (output $goLocation "env" "GOBIN") -}}
+  {{- if eq $goBin "" -}}
+    {{- $goPath := trim (output $goLocation "env" "GOPATH") -}}
+    {{- if ne $goPath "" -}}
+      {{- $goBin = joinPath $goPath "bin" -}}
+    {{- else -}}
+      {{- $goBin = joinPath .chezmoi.homeDir "go/bin" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if eq .chezmoi.os "windows" -}}
+    {{- $golangciLintLocation = findExecutable "golangci-lint.exe" (list $goBin) -}}
+  {{- else -}}
+    {{- $golangciLintLocation = findExecutable "golangci-lint" (list $goBin) -}}
+  {{- end -}}
+{{- end -}}
 {{- $ghLocation := "" -}}
 {{- if stat (joinPath .chezmoi.homeDir "/.local/bin/gh") -}}
   {{- $ghLocation = joinPath .chezmoi.homeDir "/.local/bin/gh" -}}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -238,6 +238,10 @@
 {{- if eq $goLocation "" -}}
   {{- $goLocation = lookPath "go" -}}
 {{- end -}}
+{{- $golangciLintLocation := findExecutable "golangci-lint" $paths -}}
+{{- if eq $golangciLintLocation "" -}}
+  {{- $golangciLintLocation = lookPath "golangci-lint" -}}
+{{- end -}}
 {{- $ghLocation := "" -}}
 {{- if stat (joinPath .chezmoi.homeDir "/.local/bin/gh") -}}
   {{- $ghLocation = joinPath .chezmoi.homeDir "/.local/bin/gh" -}}
@@ -514,6 +518,12 @@
 {{- else -}}
         {{- $goVersion := trim (output $goLocation "version") -}}
         {{- writeToStdout (printf "Go installed at %s (%s)\n" $goLocation $goVersion) -}}
+        {{- if eq $golangciLintLocation "" -}}
+                {{- writeToStdout "Can't find golangci-lint. Suggestion: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest\n" -}}
+        {{- else -}}
+                {{- $golangciLintVersion := trim (output $golangciLintLocation "version") -}}
+                {{- writeToStdout (printf "golangci-lint installed at %s (%s)\n" $golangciLintLocation $golangciLintVersion) -}}
+        {{- end -}}
 {{- end -}}
 
 {{- if not (stat $gitTagIncLocation ) -}}
@@ -643,6 +653,7 @@
         btopLocation="{{$btopLocation}}"
         flutterLocation="{{$flutterLocation}}"
         goLocation="{{$goLocation}}"
+        golangciLintLocation="{{$golangciLintLocation}}"
         ghLocation="{{$ghLocation}}"
         ksshaskpassLocation="{{$ksshaskpassLocation}}"
         gitTagIncLocation="{{$gitTagIncLocation}}"

--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@ porting them to chezmoi was I guess for my own interest sake.
 
 # Usage
 
-## Quick start
-
-To install the go linter:
-```sh
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-```
-
 I recommend you copy and paste the good stuff out into your own chezmoi config rather than just mine there is a lot of
 config here which is specific to me or specific to a particular situation I had been in in the past.
 
@@ -52,6 +45,15 @@ Highlights include:
   `gh-release.sh` when dependencies such as the GitHub CLI (`gh`) are absent.
 
 Feel free to copy individual pieces or adapt the whole setup to suit your needs.
+
+## Dev Tools
+
+### Quick start
+
+To install the go linter:
+```sh
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+```
 
 ## Flatpak Apps
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,9 @@ Feel free to copy individual pieces or adapt the whole setup to suit your needs.
 
 ## Dev Tools
 
-### Quick start
-
-To install the go linter:
-```sh
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-```
+| Tool | Installation Command |
+|---|---|
+| golangci-lint | `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest` |
 
 ## Flatpak Apps
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ porting them to chezmoi was I guess for my own interest sake.
 
 # Usage
 
+## Quick start
+
+To install the go linter:
+```sh
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+```
+
 I recommend you copy and paste the good stuff out into your own chezmoi config rather than just mine there is a lot of
 config here which is specific to me or specific to a particular situation I had been in in the past.
 


### PR DESCRIPTION
This PR updates the Chezmoi configuration to automatically check for `golangci-lint` if Go is installed. If found, it prints the version; otherwise, it suggests the command to install it. It also adds this command to the `README.md` under a new `Quick start` section, addressing the feature request.

---
*PR created automatically by Jules for task [8065647958892896167](https://jules.google.com/task/8065647958892896167) started by @arran4*