### PR TITLE
Update CI cron schedule to 5AM AEST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ on:
         default: true
         type: boolean
   schedule:
-    - cron: '17 3 1 * *'
-    - cron: '41 2 * * *'
+    - cron: '17 19 1 * *'
+    - cron: '41 19 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -116,10 +116,10 @@ jobs:
               ;;
             schedule)
               run_code_checks=true
-              if [[ "${{ github.event.schedule }}" == "17 3 1 * *" ]]; then
+              if [[ "${{ github.event.schedule }}" == "17 19 1 * *" ]]; then
                 is_monthly=true
               fi
-              if [[ "${{ github.event.schedule }}" == "41 2 * * *" ]]; then
+              if [[ "${{ github.event.schedule }}" == "41 19 * * *" ]]; then
                 is_nightly=true
               fi
               ;;


### PR DESCRIPTION
This PR updates the GitHub Actions cron schedules in `.github/workflows/ci.yml` to trigger at 5 AM AEST (Australian Eastern Standard Time, which is UTC+10) as requested. 

The original schedules for 3 AM UTC and 2 AM UTC have been updated to 19:00 UTC (the previous day), maintaining the same minute intervals (17 and 41). The conditional matching blocks under `schedule)` have also been correctly updated.

---
*PR created automatically by Jules for task [5529850514231428767](https://jules.google.com/task/5529850514231428767) started by @arran4*