### PR TITLE
fix: make wget hsts-file config conditional

### DIFF
--- a/dot_wgetrc.tmpl
+++ b/dot_wgetrc.tmpl
@@ -4,4 +4,8 @@ server_response = on
 # Use the server-provided last modification date, if available
 timestamping = on
 
+{{- if lookPath "wget" }}
+{{- if (output "wget" "--help") | contains "hsts-file" }}
 hsts-file=~/.cache/wget-hsts
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Fixes issue where older versions of wget (like on PocketCHIP) fail because they don't support the hsts-file directive. Now checks if the installed wget version supports it before adding it to the generated .wgetrc.

---
*PR created automatically by Jules for task [1892125938298264451](https://jules.google.com/task/1892125938298264451) started by @arran4*