### PR TITLE
Move git user configuration to create_dot_gitconfig.local.tmpl

### DIFF
--- a/create_dot_gitconfig.local.tmpl
+++ b/create_dot_gitconfig.local.tmpl
@@ -1,3 +1,3 @@
 [user]
-  # name = Local User
-  # email = local.user@example.com
+  name = {{ index . "gitUserName" }}
+  email = {{ index . "gitUserEmail" }}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -5,8 +5,6 @@
 {{- $pagerTool := index . "gitPagerLocation" -}}
 
 [user]
-  name = {{ index . "gitUserName" }}
-  email = {{ index . "gitUserEmail" }}
   useConfigOnly = true
 [init]
   defaultBranch = main


### PR DESCRIPTION
Move git user configuration to create_dot_gitconfig.local.tmpl

This removes the user name and email from `dot_gitconfig.tmpl` (leaving
only `useConfigOnly = true` under the `[user]` section) and adds the
templated name and email into `create_dot_gitconfig.local.tmpl`.
This ensures user configurations are correctly managed locally.

---
*PR created automatically by Jules for task [5088928759037547736](https://jules.google.com/task/5088928759037547736) started by @arran4*